### PR TITLE
Feat/swagger schema

### DIFF
--- a/@types/decorators.d.ts
+++ b/@types/decorators.d.ts
@@ -3,7 +3,7 @@
 
 import { Constructible, ApiPropertyDefinition, TMiddleware } from './interfaces';
 import { HttpCode, Scopes } from './enums';
-import { OpenAPISchema } from './openapi';
+import { HttpError } from './utils';
 
 
 export function Controller(path: string, ...middlewares: TMiddleware[]): ClassDecorator;
@@ -68,57 +68,39 @@ export function routeRequestParamDecorator(type: string): (varName?: string) => 
 
 // --- Swagger decorators ---
 
-/**
- * Documents API endpoint with summary, description and tags
- */
+/** Documents API endpoint */
 export function ApiOperation(summary: string, description?: string, tags?: string[]): MethodDecorator;
-/**
- * Documents API response with status code, description and schema
- */
-export function ApiResponse(statusCode: number, description: string, schema?: ApiPropertyDefinition): MethodDecorator;
-/**
- * Documents API response with schema reference only (description will be the schema name)
- */
-export function ApiResponse(statusCode: number, schemaRef: Constructible): MethodDecorator;
-/**
- * Defines property for a class API schema
- * @default schema.required true
- */
-export function ApiProperty(schema?: ApiPropertyDefinition): PropertyDecorator;
+/** Documents API response */
+export function ApiResponse(statusCode: number, description: string, definition?: ApiPropertyDefinition): MethodDecorator;
+/** Documents API response with class reference only (description will be the schema name) */
+export function ApiResponse(statusCode: number, ClassRef: Constructible): MethodDecorator;
+/** Documents API error response with base error schema and custom properties schema (record or class reference) */
+export function ApiErrorResponse<T extends HttpError>(statusCode: number, description: string, ErrorDataClass?: Constructible<T>): MethodDecorator;
+/** Documents API error response with class reference only for custom properties (description will be the schema name) */
+export function ApiErrorResponse<T extends HttpError>(statusCode: number, ErrorDataClass?: Constructible<T>): MethodDecorator;
+/** Defines property for a class API schema
+ *  @default schema.required true */
+export function ApiProperty(definition?: ApiPropertyDefinition): PropertyDecorator;
 /** Alias for '@ApiProperty()` */
-export function AP(schema?: ApiPropertyDefinition): PropertyDecorator;
-/**
- * Defines non-required property for a class API schema
- */
-export function ApiPropertyOptional(schema?: ApiPropertyDefinition): PropertyDecorator;
+export function AP(definition?: ApiPropertyDefinition): PropertyDecorator;
+/** Defines non-required property for a class API schema */
+export function ApiPropertyOptional(definition?: ApiPropertyDefinition): PropertyDecorator;
 /** Alias for `@ApiPropertyOptional()` */
-export function APO(schema?: ApiPropertyDefinition): PropertyDecorator;
-/**
- * Defines custom name for a class API schema
- * @default name Class.name // if non-decorated
- */
+export function APO(definition?: ApiPropertyDefinition): PropertyDecorator;
+/** Defines custom name for a class API schema
+ *  @default name Class.name // if non-decorated */
 export function ApiSchema(name: string): ClassDecorator;
-/**
- * Documents request body schema and content type
- * @default contentType "application/json"
- */
-export function ApiBody(description?: string, schema?: ApiPropertyDefinition, contentType?: string): MethodDecorator;
-/**
- * Documents request body with schema reference only (description will be the schema name, contentType "application/json")
- */
-export function ApiBody(schemaRef: Constructible): MethodDecorator;
-/**
- * Documents path parameter with validation schema
- * @default required false
- */
-export function ApiParam(name: string, description?: string, required?: boolean, schema?: OpenAPISchema): MethodDecorator;
-/**
- * Documents query parameter with validation schema
- * @default required false
- */
-export function ApiQuery(name: string, description?: string, required?: boolean, schema?: OpenAPISchema): MethodDecorator;
-/**
- * Documents header parameter with validation schema
- * @default required false
- */
-export function ApiHeader(name: string, description?: string, required?: boolean, schema?: OpenAPISchema): MethodDecorator;
+/** Documents request body schema and content type
+ *  @default contentType "application/json" */
+export function ApiBody(description?: string, definition?: ApiPropertyDefinition, contentType?: string): MethodDecorator;
+/** Documents request body with class reference only (description will be the schema name, contentType "application/json") */
+export function ApiBody(ClassRef: Constructible): MethodDecorator;
+/** Documents path parameter with validation schema
+ *  @default required false */
+export function ApiParam(name: string, description?: string, required?: boolean, definition?: ApiPropertyDefinition): MethodDecorator;
+/** Documents query parameter with validation schema
+ *  @default required false */
+export function ApiQuery(name: string, description?: string, required?: boolean, definition?: ApiPropertyDefinition): MethodDecorator;
+/** Documents header parameter with validation schema
+ *  @default required false */
+export function ApiHeader(name: string, description?: string, required?: boolean, definition?: ApiPropertyDefinition): MethodDecorator;

--- a/@types/decorators.d.ts
+++ b/@types/decorators.d.ts
@@ -1,6 +1,6 @@
 /* eslint-disable max-len */
 
-import { TMiddleware } from './interfaces';
+import { TApiProperty, TMiddleware } from './interfaces';
 import { HttpCode, Scopes } from './enums';
 import { OpenAPISchema } from './openapi';
 
@@ -67,15 +67,33 @@ export function routeRequestParamDecorator(type: string): (varName?: string) => 
 
 // --- Swagger decorators ---
 
-/** Documents API endpoint with summary, description and tags */
+/**
+ * Documents API endpoint with summary, description and tags
+ */
 export function ApiOperation(summary: string, description?: string, tags?: string[]): MethodDecorator;
-/** Documents API response with status code, description and schema */
-export function ApiResponse(statusCode: number, description: string, schema?: OpenAPISchema): MethodDecorator;
+/**
+ * Documents API response with status code, description and schema
+ */
+export function ApiResponse(statusCode: number, description: string, schema?: TApiProperty): MethodDecorator;
+/**
+ * Defines property for a class API schema
+ * @default schema.required true
+ */
+export function ApiProperty(schema?: TApiProperty): PropertyDecorator;
+/**
+ * Defines non-required property for a class API schema
+ */
+export function ApiPropertyOptional(schema?: TApiProperty): PropertyDecorator;
+/**
+ * Defines custom name for a class API schema
+ * @default name Class.name // if non-decorated
+ */
+export function ApiSchema(name: string): ClassDecorator;
 /**
  * Documents request body schema and content type
  * @default contentType "application/json"
  */
-export function ApiBody(description?: string, schema?: OpenAPISchema, contentType?: string): MethodDecorator;
+export function ApiBody(description?: string, schema?: TApiProperty, contentType?: string): MethodDecorator;
 /**
  * Documents path parameter with validation schema
  * @default required false
@@ -91,3 +109,8 @@ export function ApiQuery(name: string, description?: string, required?: boolean,
  * @default required false
  */
 export function ApiHeader(name: string, description?: string, required?: boolean, schema?: OpenAPISchema): MethodDecorator;
+
+/** Alias for '@ApiProperty()` */
+export const AP: PropertyDecorator;
+/** Alias for `@ApiPropertyOptional()` */
+export const APO: PropertyDecorator;

--- a/@types/decorators.d.ts
+++ b/@types/decorators.d.ts
@@ -1,6 +1,7 @@
+/* eslint-disable no-redeclare */
 /* eslint-disable max-len */
 
-import { TApiProperty, TMiddleware } from './interfaces';
+import { Constructible, ApiPropertyDefinition, TMiddleware } from './interfaces';
 import { HttpCode, Scopes } from './enums';
 import { OpenAPISchema } from './openapi';
 
@@ -74,16 +75,24 @@ export function ApiOperation(summary: string, description?: string, tags?: strin
 /**
  * Documents API response with status code, description and schema
  */
-export function ApiResponse(statusCode: number, description: string, schema?: TApiProperty): MethodDecorator;
+export function ApiResponse(statusCode: number, description: string, schema?: ApiPropertyDefinition): MethodDecorator;
+/**
+ * Documents API response with schema reference only (description will be the schema name)
+ */
+export function ApiResponse(statusCode: number, schemaRef: Constructible): MethodDecorator;
 /**
  * Defines property for a class API schema
  * @default schema.required true
  */
-export function ApiProperty(schema?: TApiProperty): PropertyDecorator;
+export function ApiProperty(schema?: ApiPropertyDefinition): PropertyDecorator;
+/** Alias for '@ApiProperty()` */
+export function AP(schema?: ApiPropertyDefinition): PropertyDecorator;
 /**
  * Defines non-required property for a class API schema
  */
-export function ApiPropertyOptional(schema?: TApiProperty): PropertyDecorator;
+export function ApiPropertyOptional(schema?: ApiPropertyDefinition): PropertyDecorator;
+/** Alias for `@ApiPropertyOptional()` */
+export function APO(schema?: ApiPropertyDefinition): PropertyDecorator;
 /**
  * Defines custom name for a class API schema
  * @default name Class.name // if non-decorated
@@ -93,7 +102,11 @@ export function ApiSchema(name: string): ClassDecorator;
  * Documents request body schema and content type
  * @default contentType "application/json"
  */
-export function ApiBody(description?: string, schema?: TApiProperty, contentType?: string): MethodDecorator;
+export function ApiBody(description?: string, schema?: ApiPropertyDefinition, contentType?: string): MethodDecorator;
+/**
+ * Documents request body with schema reference only (description will be the schema name, contentType "application/json")
+ */
+export function ApiBody(schemaRef: Constructible): MethodDecorator;
 /**
  * Documents path parameter with validation schema
  * @default required false
@@ -109,8 +122,3 @@ export function ApiQuery(name: string, description?: string, required?: boolean,
  * @default required false
  */
 export function ApiHeader(name: string, description?: string, required?: boolean, schema?: OpenAPISchema): MethodDecorator;
-
-/** Alias for '@ApiProperty()` */
-export const AP: PropertyDecorator;
-/** Alias for `@ApiPropertyOptional()` */
-export const APO: PropertyDecorator;

--- a/@types/enums/reflect.enum.ts
+++ b/@types/enums/reflect.enum.ts
@@ -1,4 +1,4 @@
-import { IControllerRoute, Instance, IRouteParam, TApiProperty } from '../interfaces';
+import { IControllerRoute, Instance, IRouteParam, ApiPropertyDefinition } from '../interfaces';
 import { HttpCode } from './http-code.enum';
 import { Scopes } from './scopes.enum';
 import { OpenAPIOperation } from '../openapi';
@@ -35,6 +35,6 @@ export interface ReflectTypes {
   [ReflectMetadata.SELF]: Instance;
   [ReflectMetadata.INJECTABLE]: boolean;
   [ReflectMetadata.SWAGGER_OPERATION]: OpenAPIOperation;
-  [ReflectMetadata.SWAGGER_SCHEMA_DEFINITION]: Record<string, TApiProperty>;
+  [ReflectMetadata.SWAGGER_SCHEMA_DEFINITION]: Record<string, ApiPropertyDefinition>;
   [ReflectMetadata.SWAGGER_SCHEMA_NAME]: string;
 }

--- a/@types/enums/reflect.enum.ts
+++ b/@types/enums/reflect.enum.ts
@@ -1,11 +1,12 @@
-import { IControllerRoute, Instance, IRouteParam } from '../interfaces';
+import { IControllerRoute, Instance, IRouteParam, TApiProperty } from '../interfaces';
 import { HttpCode } from './http-code.enum';
 import { Scopes } from './scopes.enum';
 import { OpenAPIOperation } from '../openapi';
 
 
 export enum ReflectMetadata {
-  DESIGN_TYPE = 'design:paramtypes',
+  DESIGN_TYPE = 'design:type',
+  DESIGN_PARAM_TYPES = 'design:paramtypes',
   PRE_INJECTED_DEPS = 'PRE_INJECTED_DEPS',
   DEP_SCOPES = 'DEP_SCOPES',
   METHOD_INJECTED_DEPS = 'METHOD_INJECTED_DEPS',
@@ -14,12 +15,15 @@ export enum ReflectMetadata {
   HTTP_STATUS = 'HTTP_STATUS',
   PARAMS = 'PARAMS',
   SELF = 'SELF',
-  SWAGGER = 'SWAGGER',
   INJECTABLE = 'INJECTABLE',
+  SWAGGER_OPERATION = 'SWG_OPS',
+  SWAGGER_SCHEMA_DEFINITION = 'SWG_SCHEMA_DEF',
+  SWAGGER_SCHEMA_NAME = 'SWG_SCHEMA_NAME',
 }
 
 export interface ReflectTypes {
-  [ReflectMetadata.DESIGN_TYPE]: Function[];
+  [ReflectMetadata.DESIGN_TYPE]: Function;
+  [ReflectMetadata.DESIGN_PARAM_TYPES]: Function[];
   [ReflectMetadata.PRE_INJECTED_DEPS]: Record<number, string>;
   [ReflectMetadata.DEP_SCOPES]: Record<number, Scopes>;
   [ReflectMetadata.METHOD_INJECTED_DEPS]: Record<string, Record<number, Function | string>>;
@@ -29,6 +33,8 @@ export interface ReflectTypes {
   [ReflectMetadata.HTTP_STATUS]: HttpCode;
   [ReflectMetadata.PARAMS]: IRouteParam[];
   [ReflectMetadata.SELF]: Instance;
-  [ReflectMetadata.SWAGGER]: OpenAPIOperation;
   [ReflectMetadata.INJECTABLE]: boolean;
+  [ReflectMetadata.SWAGGER_OPERATION]: OpenAPIOperation;
+  [ReflectMetadata.SWAGGER_SCHEMA_DEFINITION]: Record<string, TApiProperty>;
+  [ReflectMetadata.SWAGGER_SCHEMA_NAME]: string;
 }

--- a/@types/interfaces/controller.i.ts
+++ b/@types/interfaces/controller.i.ts
@@ -24,5 +24,6 @@ export interface IControllerRoute {
 
 export interface IRouteParam {
   index: number;
+  type: Function;
   path: string[];
 }

--- a/@types/interfaces/swagger.i.ts
+++ b/@types/interfaces/swagger.i.ts
@@ -1,11 +1,25 @@
 import { IControllerRoute, TController } from './controller.i';
+import { Constructible } from './utils.i';
 import {
+  ObjectSchema,
   OpenAPIComponents,
   OpenAPIInfo,
   OpenAPIOperation,
   OpenAPIPathItem,
+  OpenAPISchema,
   OpenAPIServer,
+  RefSchema,
 } from '../openapi';
+
+
+export type ApiPropertySchema =
+  | ObjectSchema
+  | RefSchema
+  | (Exclude<OpenAPISchema, ObjectSchema | RefSchema> & {
+    required?: boolean;
+  });
+
+export type TApiProperty = ApiPropertySchema | Constructible;
 
 
 export interface ISwaggerRoute extends IControllerRoute {

--- a/@types/interfaces/swagger.i.ts
+++ b/@types/interfaces/swagger.i.ts
@@ -28,7 +28,7 @@ export type ApiPropertyEnumSchema = {
   enum: (string | number)[] | Record<string, string | number>;
 };
 
-/** Swagger decorators (ApiProperty, ApiResponse, ApiBody) usage */
+/** Swagger decorators usage */
 export type ApiPropertyDefinition =
   | ApiPropertyPrimitiveSchema
   | ObjectSchema

--- a/@types/interfaces/swagger.i.ts
+++ b/@types/interfaces/swagger.i.ts
@@ -12,14 +12,31 @@ import {
 } from '../openapi';
 
 
-export type ApiPropertySchema =
+export type ApiPropertyPrimitiveSchema = Exclude<OpenAPISchema, ObjectSchema | RefSchema> & {
+  required?: boolean;
+};
+
+export type SafeApiPropertyRecord = {
+  type?: never;
+  $ref?: never;
+  enum?: never;
+} & {
+  [K in string]: (Constructible | [Constructible]) | SafeApiPropertyRecord;
+};
+
+export type ApiPropertyEnumSchema = {
+  enum: (string | number)[] | Record<string, string | number>;
+};
+
+/** Swagger decorators (ApiProperty, ApiResponse, ApiBody) usage */
+export type ApiPropertyDefinition =
+  | ApiPropertyPrimitiveSchema
   | ObjectSchema
   | RefSchema
-  | (Exclude<OpenAPISchema, ObjectSchema | RefSchema> & {
-    required?: boolean;
-  });
-
-export type TApiProperty = ApiPropertySchema | Constructible;
+  | ApiPropertyEnumSchema
+  | Constructible
+  | [Constructible]
+  | SafeApiPropertyRecord;
 
 
 export interface ISwaggerRoute extends IControllerRoute {

--- a/@types/utils.d.ts
+++ b/@types/utils.d.ts
@@ -1,6 +1,6 @@
 import { HttpCode } from './enums';
 import { ApiPropertyDefinition } from './interfaces';
-import { ObjectSchema, OpenAPISchema } from './openapi';
+import { OpenAPISchema } from './openapi';
 
 
 /** Error class for custom error handling */
@@ -14,15 +14,6 @@ export declare class HttpError extends Error {
   public status?: HttpCode;
   constructor(status: HttpCode, message: string);
 }
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function ErrorResourceSchema<T extends Record<string, any> = Record<string, any>>(
-  /** Additional schema properties to merge with base error schema */
-  additionalProperties: Record<string, OpenAPISchema>,
-  /** Example object for the combined error schema */
-  additionalPropertiesExample?: T,
-): ObjectSchema;
-
 
 /** Returns a reference OpenAPI schema for a given resource */
 export function resolveSchema(schema: ApiPropertyDefinition): OpenAPISchema;

--- a/@types/utils.d.ts
+++ b/@types/utils.d.ts
@@ -1,5 +1,5 @@
 import { HttpCode } from './enums';
-import { OpenAPISchema } from './openapi';
+import { ObjectSchema, OpenAPISchema } from './openapi';
 
 
 /** Error class for custom error handling */
@@ -20,4 +20,4 @@ export function ErrorResourceSchema<T extends Record<string, any> = Record<strin
   additionalProperties: Record<string, OpenAPISchema>,
   /** Example object for the combined error schema */
   additionalPropertiesExample?: T,
-): OpenAPISchema;
+): ObjectSchema;

--- a/@types/utils.d.ts
+++ b/@types/utils.d.ts
@@ -1,4 +1,5 @@
 import { HttpCode } from './enums';
+import { ApiPropertyDefinition } from './interfaces';
 import { ObjectSchema, OpenAPISchema } from './openapi';
 
 
@@ -21,3 +22,7 @@ export function ErrorResourceSchema<T extends Record<string, any> = Record<strin
   /** Example object for the combined error schema */
   additionalPropertiesExample?: T,
 ): ObjectSchema;
+
+
+/** Returns a reference OpenAPI schema for a given resource */
+export function resolveSchema(schema: ApiPropertyDefinition): OpenAPISchema;

--- a/commit-config.json
+++ b/commit-config.json
@@ -1,5 +1,6 @@
 {
   "format": 1,
+  "branchFormat": 1,
   "types": [
     {
       "value": "fix",

--- a/docs/.vitepress/config/en.ts
+++ b/docs/.vitepress/config/en.ts
@@ -12,7 +12,8 @@ export default {
       { text: 'Team', link: '/team' },
     ],
     socialLinks: [
-      { icon: 'github', link: 'https://github.com/thomasbarkats/yasui' }
+      { icon: 'github', link: 'https://github.com/thomasbarkats/yasui' },
+      { icon: 'npm', link: 'http://npmjs.com/package/yasui' }
     ],
     sidebar: [
       {
@@ -32,7 +33,7 @@ export default {
           { text: 'Dependency Injection', link: '/reference/dependency-injection' },
           { text: 'Logging', link: '/reference/logging' },
           { text: 'Error Handling', link: '/reference/error-handling' },
-          { text: 'Swagger', link: '/reference/swagger' }
+          { text: 'Swagger Doc.', link: '/reference/swagger' }
         ]
       }
     ]

--- a/docs/.vitepress/config/es.ts
+++ b/docs/.vitepress/config/es.ts
@@ -12,7 +12,8 @@ export default {
       { text: 'Equipo', link: '/es/team' },
     ],
     socialLinks: [
-      { icon: 'github', link: 'https://github.com/thomasbarkats/yasui' }
+      { icon: 'github', link: 'https://github.com/thomasbarkats/yasui' },
+      { icon: 'npm', link: 'http://npmjs.com/package/yasui' }
     ],
     sidebar: [
       {
@@ -32,7 +33,7 @@ export default {
           { text: 'Inyección de Dependencias', link: '/es/reference/dependency-injection' },
           { text: 'Registro de Eventos', link: '/es/reference/logging' },
           { text: 'Manejo de Errores', link: '/es/reference/error-handling' },
-          { text: 'Swagger', link: '/es/reference/swagger' }
+          { text: 'Swagger Doc.', link: '/es/reference/swagger' }
         ]
       }
     ]

--- a/docs/.vitepress/config/fr.ts
+++ b/docs/.vitepress/config/fr.ts
@@ -12,7 +12,8 @@ export default {
       { text: 'Équipe', link: '/fr/team' },
     ],
     socialLinks: [
-      { icon: 'github', link: 'https://github.com/thomasbarkats/yasui' }
+      { icon: 'github', link: 'https://github.com/thomasbarkats/yasui' },
+      { icon: 'npm', link: 'http://npmjs.com/package/yasui' }
     ],
     sidebar: [
       {
@@ -32,7 +33,7 @@ export default {
           { text: 'Injection de dépendances', link: '/fr/reference/dependency-injection' },
           { text: 'Journalisation', link: '/fr/reference/logging' },
           { text: 'Gestion des erreurs', link: '/fr/reference/error-handling' },
-          { text: 'Swagger', link: '/fr/reference/swagger' }
+          { text: 'Swagger Doc.', link: '/fr/reference/swagger' }
         ]
       }
     ]

--- a/docs/.vitepress/config/zh.ts
+++ b/docs/.vitepress/config/zh.ts
@@ -12,7 +12,8 @@ export default {
       { text: '团队', link: '/zh/team' },
     ],
     socialLinks: [
-      { icon: 'github', link: 'https://github.com/thomasbarkats/yasui' }
+      { icon: 'github', link: 'https://github.com/thomasbarkats/yasui' },
+      { icon: 'npm', link: 'http://npmjs.com/package/yasui' }
     ],
     sidebar: [
       {
@@ -32,7 +33,7 @@ export default {
           { text: '依赖注入', link: '/zh/reference/dependency-injection' },
           { text: '日志', link: '/zh/reference/logging' },
           { text: '错误处理', link: '/zh/reference/error-handling' },
-          { text: 'Swagger', link: '/zh/reference/swagger' }
+          { text: 'Swagger 文档', link: '/zh/reference/swagger' }
         ]
       }
     ]

--- a/docs/.vitepress/theme/style.css
+++ b/docs/.vitepress/theme/style.css
@@ -3,7 +3,7 @@
   --vp-c-brand-2: #C4851F;
   --vp-c-brand-3: #B57615;
   --vp-c-brand-4: #CC855F;
-  --vp-c-brand-soft: rgba(210, 147, 44, 0.14);
+  --vp-c-brand-shadow: #dba78a;
 }
 
 /* Dark mode colors */
@@ -12,7 +12,7 @@
   --vp-c-brand-2: #DCA347;
   --vp-c-brand-3: #D2932C;
   --vp-c-brand-4: #996447;
-  --vp-c-brand-soft: rgba(232, 181, 90, 0.16);
+  --vp-c-brand-shadow: #754931;
 }
 
 :root {
@@ -25,7 +25,7 @@
 }
 
 .VPImage {
-  filter: drop-shadow(-8px 8px 64px var(--vp-c-brand-4));
+  filter: drop-shadow(-8px 8px 64px var(--vp-c-brand-shadow));
 }
 
 .VPHero .main {

--- a/docs/en/guide/getting-started.md
+++ b/docs/en/guide/getting-started.md
@@ -95,10 +95,6 @@ Visit `http://localhost:3000` and you'll see:
 
 Congratulations! You have a working YasuiJS API.
 
-## Examples
-
-Check out the [complete examples](https://github.com/thomasbarkats/yasui/tree/main/src/examples) in the YasuiJS repository for more patterns and use cases.
-
 ## Need Help?
 
 If you encounter any issues:

--- a/docs/en/reference/config.md
+++ b/docs/en/reference/config.md
@@ -20,7 +20,7 @@ Both methods accept the same configuration object with the following options.
 **Description:** Array of controller classes to register in your application.
 
 ```typescript
-import { UserController, ProductController } from './controllers';
+import yasui from 'yasui';
 
 yasui.createServer({
   controllers: [UserController, ProductController]
@@ -35,9 +35,6 @@ yasui.createServer({
 **Description:** Array of global middlewares to apply to all requests. Can be YasuiJS middleware classes or Express RequestHandler functions.
 
 ```typescript
-import { LoggingMiddleware } from './middleware';
-import cors from 'cors';
-
 yasui.createServer({
   controllers: [UserController],
   middlewares: [LoggingMiddleware, cors()]
@@ -188,9 +185,6 @@ app.listen(3000, () => {
 ### Basic API Setup
 
 ```typescript
-import yasui from 'yasui';
-import { UserController, AuthController } from './controllers';
-
 yasui.createServer({
   controllers: [UserController, AuthController],
   port: 3000,
@@ -201,10 +195,6 @@ yasui.createServer({
 ### Complete Configuration
 
 ```typescript
-import yasui from 'yasui';
-import { UserController, AuthController } from './controllers';
-import { AuthMiddleware, LoggingMiddleware } from './middleware';
-
 yasui.createServer({
   controllers: [UserController, AuthController],
   middlewares: [LoggingMiddleware, AuthMiddleware],

--- a/docs/en/reference/dependency-injection.md
+++ b/docs/en/reference/dependency-injection.md
@@ -125,19 +125,16 @@ You can inject dependencies directly into controller or middleware method parame
 ```typescript
 @Controller('/users')
 export class UserController {
-  constructor(private userService: UserService) {} // Shared instance for the controller
+
+  // Shared instance for the controller
+  constructor(private userService: UserService) {}
 
   @Get('/:id')
   getUser(
     @Param('id') id: string,
-    @Inject() userService: UserService // Instance specific to this endpoint
+    @Inject() userService: UserService // Specific instance to this endpoint
   ) {
     return userService.getUser(id);
-  }
-
-  @Get('/')
-  getUsers(@Inject() userService: UserService) {
-    return userService.getAllUsers();
   }
 }
 ```

--- a/docs/en/reference/middlewares.md
+++ b/docs/en/reference/middlewares.md
@@ -34,8 +34,11 @@ export class LoggingMiddleware {
 The `@Middleware()` decorator defines a class as middleware. The class must implement a `use()` method. You can optionally implement the `IMiddleware` interface provided by YasuiJS to enforce the method signature.
 
 ```typescript
-import { Middleware, IMiddleware, Req, Res, Next } from 'yasui';
-import { Request, Response, NextFunction } from 'express';
+import {
+  Middleware, IMiddleware,
+  Request, Response, NextFunction,
+  Req, Res, Next,
+} from 'yasui';
 
 @Middleware()
 export class AuthMiddleware implements IMiddleware {
@@ -49,9 +52,9 @@ export class AuthMiddleware implements IMiddleware {
     if (!token) {
       return res.status(401).json({ error: 'Unauthorized' });
     }
-    
     // Validate token logic here
-    next(); // Continue to next middleware or controller
+
+    next(); // Continue to next middleware or controller logic
   }
 }
 ```
@@ -109,28 +112,11 @@ You can use standard Express middleware functions directly:
 ```typescript
 import cors from 'cors';
 import helmet from 'helmet';
-import { Request, Response, NextFunction } from 'express';
-
-// Function middleware
-function customMiddleware(req: Request, res: Response, next: NextFunction) {
-  console.log(`${req.method} ${req.path}`);
-  next();
-}
-
-// Function that returns middleware
-function rateLimiter(maxRequests: number) {
-  return (req: Request, res: Response, next: NextFunction) => {
-    // Rate limiting logic
-    next();
-  };
-}
 
 yasui.createServer({
   middlewares: [
     cors(),
     helmet(),
-    customMiddleware,
-    rateLimiter(100)
   ]
 });
 ```
@@ -142,9 +128,6 @@ yasui.createServer({
 Applied to all requests across your entire application:
 
 ```typescript
-import yasui from 'yasui';
-import { LoggingMiddleware, SecurityMiddleware } from './middleware';
-
 yasui.createServer({
   controllers: [UserController],
   middlewares: [LoggingMiddleware, SecurityMiddleware]
@@ -156,8 +139,6 @@ yasui.createServer({
 Applied to all routes within a specific controller:
 
 ```typescript
-import { AuthMiddleware, ValidationMiddleware } from './middleware';
-
 // Single middleware
 @Controller('/api/users', AuthMiddleware)
 export class UserController {
@@ -176,8 +157,6 @@ export class AdminController {
 Applied to specific routes only:
 
 ```typescript
-import { AuthMiddleware, ValidationMiddleware } from './middleware';
-
 @Controller('/api/users')
 export class UserController {
   @Get('/')

--- a/docs/en/reference/swagger.md
+++ b/docs/en/reference/swagger.md
@@ -6,7 +6,7 @@ YasuiJS provides OpenAPI documentation generation with optional Swagger UI integ
 
 ### Basic Setup
 
-Enable Swagger by adding configuration to your app. YasuiJS automatically generates documentation from your controllers, routes, and decorators.
+Enable Swagger by adding configuration to your app. YasuiJS generates documentation from your controllers, routes, and decorators.
 
 **Note**: You need to install `swagger-ui-express` separately:
 ```bash
@@ -16,17 +16,18 @@ npm install swagger-ui-express
 ```typescript
 yasui.createServer({
   controllers: [UserController],
-  swagger: {
-    enabled: true,
-    info: {
-      title: 'My API',
-      version: '1.0.0'
-    }
-  }
+  swagger: { enabled: true }
 });
 ```
 
-The documentation will be accessible at `/api-docs` (default path) and the JSON specification at `/api-docs.json`.
+Documentation will be accessible at `/api-docs` (default path) and JSON specification at `/api-docs/swagger.json`.
+
+YasuiJS automatically generates basic documentation from your existing controllers and route decorators, even without any Swagger-specific decorators. The framework detects:
+- **Parameters**: Path parameters, query parameters, and headers are automatically detected with `string` type by default
+- **Request body**: Automatically detected when present with `{}` schema by default
+- **Responses**: Only the 200 status code (or the default status if `@HttpStatus` is present) is detected without schema information
+
+The following sections describe how to enhance this documentation with additional metadata and precise typing.
 
 ### Complete Configuration
 
@@ -35,176 +36,187 @@ yasui.createServer({
   controllers: [UserController],
   swagger: {
     enabled: true,
-    path: '/docs', // Custom path
+    path: '/docs', // Custom path, JSON specification at `/docs/swagger.json`
     info: {
       title: 'User Management API',
       version: '2.1.0',
       description: 'Complete API for user management operations',
-      contact: {
-        name: 'API Support',
-        email: 'support@example.com'
-      },
-      license: {
-        name: 'MIT',
-        url: 'https://opensource.org/licenses/MIT'
-      }
     },
-    servers: [
-      {
-        url: 'https://api.example.com/v1',
-        description: 'Production server'
-      },
-      {
-        url: 'http://localhost:3000',
-        description: 'Development server'
-      }
-    ]
   }
 });
 ```
 
-## Enhanced Documentation
+## Schema Definition
 
-Enrich the default API documentation with optional decorators. All decorators are attached to the endpoint's method:
+YasuiJS uses TypeScript classes with property decorators to define API schemas. Properties are automatically inferred from TypeScript metadata when decorators are used without parameters.
 
-### API Operation
+Schemas are automatically registered if they are used in any decorators.
 
-- `@ApiOperation(summary, description?, tags?)` - Describe the endpoint
+### `@ApiProperty(definition?)`
+Defines a property, default required. Supports multiple definition formats:
 
 ```typescript
-import { ApiOperation } from 'yasui';
+export class CreateUserDto {
+  @ApiProperty() // Type inferred from TypeScript
+  name: string;
 
-@Controller('/users')
-export class UserController {
-  @Get('/')
-  @ApiOperation('Get all users', 'Retrieve a list of all users in the system', ['users'])
-  getUsers() {
-    return this.userService.getAllUsers();
-  }
+  @ApiProperty({ type: 'string', format: 'email' }) // OpenAPI schema, full customization
+  username: string;
 
-  @Post('/')
-  @ApiOperation('Create user', 'Create a new user account')
-  createUser(@Body() userData: any) {
-    return this.userService.createUser(userData);
-  }
+  @ApiProperty({ enum: ['admin', 'user', 'moderator'] }) // Enum values
+  role: string;
+
+  @ApiProperty({ enum: UserStatus }) // TypeScript enum
+  status: UserStatus;
+
+  @ApiProperty([String]) // Array of primitives
+  tags: string[];
+
+  @ApiProperty(AddressDto) // Reference to another class
+  address: AddressDto;
+
+  @ApiProperty([AddressDto]) // Array of class references
+  previousAddresses: AddressDto[];
+
+  @ApiProperty({
+    theme: String,
+    preferences: PreferencesDto,
+    categories: [String],
+    addresses: [AddressDto]
+  }) // Record of previously listed usages
+  settings: any;
 }
 ```
 
-### Parameters Documentation
+Only primitive types can be inferred from TypeScript metadata. Complex types (including arrays) will default to `{ type: 'object' }`. For specific typing, use the explicit definition formats shown above.
 
-- `@ApiParam(name, description?, required?, schema?)` - Document path parameters
-- `@ApiQuery(name, description?, required?, schema?)` - Document query parameters  
-- `@ApiHeader(name, description?, required?, schema?)` - Document headers
+### `@ApiPropertyOptional(definition?)`
+Equivalent to `@ApiProperty({ required: false })`
 
 ```typescript
-import { ApiParam, ApiQuery, ApiHeader } from 'yasui';
+@ApiPropertyOptional()
+description?: string;
 
-@Controller('/users')
-export class UserController {
-  @Get('/:id')
-  @ApiParam('id', 'User unique identifier', true, { type: 'string' })
-  @ApiHeader('Authorization', 'Bearer token for authentication', true)
-  getUser(@Param('id') id: string) {
-    return this.userService.findById(id);
-  }
+@ApiPropertyOptional({ enum: ['small', 'medium', 'large'] })
+size?: string;
+```
 
-  @Get('/')
-  @ApiQuery('page', 'Page number for pagination', false, { type: 'number', default: 1 })
-  @ApiQuery('limit', 'Number of items per page', false, { type: 'number', default: 10 })
-  getUsers(
-    @Query('page') page: number = 1,
-    @Query('limit') limit: number = 10
-  ) {
-    return this.userService.getUsers({ page, limit });
-  }
+### `@ApiSchema(name)`
+Defines a custom schema name. Default name is the class name. Schema names must be unique.
+
+```typescript
+@ApiSchema('Create User Request')
+export class CreateUserDto {
+  @ApiProperty()
+  name: string;
 }
 ```
 
-### Request Body Documentation
+### Aliases
+- `@AP()` - Alias for `@ApiProperty()`
+- `@APO()` - Alias for `@ApiPropertyOptional()`
 
-- `@ApiBody(description?, schema?)` - Document request body
+## Endpoint Documentation
+
+### `@ApiBody(description?, definition?, contentType?)`
+Documents request body schema. Default content type is `application/json`.
 
 ```typescript
-import { ApiBody } from 'yasui';
+@Post('/users')
+@ApiBody('User data', CreateUserDto)
+createUser(@Body() data: CreateUserDto) {}
+```
+All definition formats described for @ApiProperty (OpenAPI schema, Array of primitives, Array of class references, Record, Enum...) are valid for @ApiBody. Schemas of any class will be automatically resolved.
 
-@Controller('/users')
-export class UserController {
-  @Post('/')
-  @ApiBody('User creation data', {
-    type: 'object',
-    properties: {
-      name: { type: 'string', description: 'User full name' },
-      email: { type: 'string', format: 'email', description: 'User email address' },
-      age: { type: 'number', minimum: 18, description: 'User age (must be 18+)' }
-    },
-    required: ['name', 'email']
-  })
-  createUser(@Body() userData: any) {
-    return this.userService.createUser(userData);
-  }
-}
+Also possible to use @ApiBody with class reference only without description (will be the schema name in this case).
+```ts
+@Post('/users')
+@ApiBody(CreateUserDto)
+createUser(@Body() data: CreateUserDto) {}
 ```
 
-### Response Documentation
-
-- `@ApiResponse(statusCode, description, schema?)` - Document responses
+### `@ApiResponse(statusCode, description?, definition?)`
+Documents endpoint responses.
 
 ```typescript
-import { ApiResponse } from 'yasui';
+@Get('/users')
+@ApiResponse(200, 'Users', [UserDto])
+getUsers() {}
+```
+All definition formats described for @ApiProperty (OpenAPI schema, Array of primitives, Array of class references, Record, Enum...) are valid for @ApiResponse. Schemas of any class will be automatically resolved.
 
-@Controller('/users')
-export class UserController {
-  @Get('/:id')
-  @ApiResponse(200, 'User found successfully', {
-    type: 'object',
-    properties: {
-      id: { type: 'string' },
-      name: { type: 'string' },
-      email: { type: 'string' },
-      createdAt: { type: 'string', format: 'date-time' }
-    }
-  })
-  @ApiResponse(404, 'User not found')
-  getUser(@Param('id') id: string) {
-    return this.userService.findById(id);
-  }
+Also possible to use @ApiResponse with class reference only without description (will be the schema name in this case).
+```typescript
+@Get('/users/:id')
+@ApiResponse(200, UserDto)
+getUser(@Param('id') id: string) {}
+```
 
-  @Post('/')
-  @ApiResponse(201, 'User created successfully')
-  @ApiResponse(400, 'Invalid user data')
-  createUser(@Body() userData: any) {
-    return this.userService.createUser(userData);
-  }
-}
+### `@ApiOperation(summary, description?, tags?)`
+Describes the endpoint operation.
+
+```typescript
+@Get('/users')
+@ApiOperation('Get all users')
+getUsers() {}
+
+@Post('/users')
+@ApiOperation('Create user', 'Creates a new user account', ['users'])
+createUser() {}
+```
+
+### Parameter Documentation
+- `@ApiParam(name, description?, required?, definition?)` - Path parameters
+- `@ApiQuery(name, description?, required?, definition?)` - Query parameters  
+- `@ApiHeader(name, description?, required?, definition?)` - Headers
+
+All definition formats described for `@ApiProperty` and previous decorators are supported, but be mindful that complex usages (objects, arrays, class references, etc.) may not make sense depending on the decorator's nature, even though the OpenAPI schema will be correctly generated.
+
+```typescript
+@Get('/users/:id')
+@ApiParam('id', 'User ID', true, Number)
+@ApiQuery('include', 'Include related data', false, Boolean)
+@ApiHeader('Authorization', 'Bearer token', true) // String by default
+getUser(
+  @Param('id') id: number,
+  @Query('include') include?: boolean
+) {}
 ```
 
 ## Error Responses
 
-`ErrorResourceSchema` generates a schema for YasuiJS's error wrapper format. You can optionally define additional fields that will be included in the `data` property for your custom errors:
+### `@ApiErrorResponse(statusCode, description?, ErrorDataClass?)`
+Documents error responses with YasuiJS error wrapper format. This decorator automatically includes the framework's complete error schema structure that wraps all errors in your application.
 
 ```typescript
-import { ApiResponse, ErrorResourceSchema } from 'yasui';
+@Get('/users/:id')
+@ApiErrorResponse(404, 'User not found')
+@ApiErrorResponse(500, 'Internal server error')
+getUser(@Param('id') id: string) {}
+```
 
-@Controller('/users')
-export class UserController {
-  @Get('/:id')
-  @ApiResponse(404, 'User not found', ErrorResourceSchema())
-  getUser(@Param('id') id: string) {
-    return this.userService.findById(id);
-  }
+When you have custom error classes that extend `HttpError`, you can enhance them with `@ApiProperty` and `@ApiPropertyOptional` decorators to document their specific properties. The resulting schema will merge your custom error data with YasuiJS's standard error wrapper:
 
-  @Post('/')
-  @ApiResponse(400, 'Validation failed', ErrorResourceSchema({
-    fields: { 
-      type: 'array', 
-      items: { type: 'string' },
-      description: 'List of invalid fields' 
-    }
-  }, {
-    fields: ['email', 'password']
-  }))
-  createUser(@Body() userData: any) {
-    return this.userService.createUser(userData);
-  }
-}
+```typescript
+@Post('/users')
+@ApiErrorResponse(400, 'Validation failed', ValidationErrorData)
+createUser(@Body() data: CreateUserDto) {}
+
+// Also possible with class reference only (description will be the schema name)
+@Post('/users')
+@ApiErrorResponse(400, ValidationErrorData)
+createUser(@Body() data: CreateUserDto) {}
+```
+
+### Alternative approach
+If you prefer simpler error documentation without the complete wrapper format, you can continue using the standard `@ApiResponse` decorator described earlier. With `@ApiResponse`, if you pass a custom error class extending HttpError, you'll only get the schema of that specific class without inheriting any API definitions.
+
+## Utility Functions
+
+### `resolveSchema(schema: ApiPropertyDefinition): OpenAPISchema`
+Manually resolves any schema definition (see formats described in @ApiProperty section) to OpenAPI format. Useful for specific use cases.
+
+```typescript
+import { resolveSchema } from 'yasui';
+const schema = resolveSchema(CreateUserDto);
 ```

--- a/docs/es/guide/getting-started.md
+++ b/docs/es/guide/getting-started.md
@@ -95,10 +95,6 @@ Visita `http://localhost:3000` y verás:
 
 ¡Felicitaciones! Tienes una API YasuiJS funcionando.
 
-## Ejemplos
-
-Revisa los [ejemplos completos](https://github.com/thomasbarkats/yasui/tree/main/src/examples) en el repositorio de YasuiJS para más patrones y casos de uso.
-
 ## ¿Necesitas Ayuda?
 
 Si encuentras algún problema:

--- a/docs/es/reference/config.md
+++ b/docs/es/reference/config.md
@@ -2,7 +2,7 @@
 
 Referencia completa de configuración para aplicaciones YasuiJS usando `yasui.createServer()` y `yasui.createApp()`.
 
-## Visión General
+## Descripción General
 
 YasuiJS proporciona dos formas principales de crear tu aplicación:
 
@@ -20,7 +20,7 @@ Ambos métodos aceptan el mismo objeto de configuración con las siguientes opci
 **Descripción:** Array de clases controladoras para registrar en tu aplicación.
 
 ```typescript
-import { UserController, ProductController } from './controllers';
+import yasui from 'yasui';
 
 yasui.createServer({
   controllers: [UserController, ProductController]
@@ -31,13 +31,10 @@ yasui.createServer({
 
 #### `middlewares`
 **Tipo:** `Array<Constructor | RequestHandler>`  
-**Por defecto:** `[]`  
+**Valor Predeterminado:** `[]`  
 **Descripción:** Array de middlewares globales para aplicar a todas las peticiones. Pueden ser clases middleware de YasuiJS o funciones RequestHandler de Express.
 
 ```typescript
-import { LoggingMiddleware } from './middleware';
-import cors from 'cors';
-
 yasui.createServer({
   controllers: [UserController],
   middlewares: [LoggingMiddleware, cors()]
@@ -46,7 +43,7 @@ yasui.createServer({
 
 #### `environment`
 **Tipo:** `string`  
-**Por defecto:** `process.env.NODE_ENV || 'development'`  
+**Valor Predeterminado:** `process.env.NODE_ENV || 'development'`  
 **Descripción:** Nombre del entorno para tu aplicación.
 
 ```typescript
@@ -58,7 +55,7 @@ yasui.createServer({
 
 #### `port`
 **Tipo:** `number`  
-**Por defecto:** `3000`  
+**Valor Predeterminado:** `3000`  
 **Descripción:** Número de puerto para el servidor HTTP. Solo se usa con `createServer()`.
 
 ```typescript
@@ -70,8 +67,8 @@ yasui.createServer({
 
 #### `debug`
 **Tipo:** `boolean`  
-**Por defecto:** `false`  
-**Descripción:** Habilita el modo debug con registro adicional y seguimiento de peticiones.
+**Valor Predeterminado:** `false`  
+**Descripción:** Habilita el modo de depuración con registro adicional y seguimiento de peticiones.
 
 ```typescript
 yasui.createServer({
@@ -82,7 +79,7 @@ yasui.createServer({
 
 #### `injections`
 **Tipo:** `Array<{ token: string, provide: any }>`  
-**Por defecto:** `[]`  
+**Valor Predeterminado:** `[]`  
 **Descripción:** Tokens de inyección personalizados para inyección de dependencias. Ver [Inyección de Dependencias](/es/reference/dependency-injection) para más detalles.
 
 ```typescript
@@ -97,7 +94,7 @@ yasui.createServer({
 
 #### `swagger`
 **Tipo:** `SwaggerConfig | undefined`  
-**Por defecto:** `undefined`  
+**Valor Predeterminado:** `undefined`  
 **Descripción:** Configuración de documentación Swagger. Ver [Swagger](/es/reference/swagger) para más detalles.
 
 ```typescript
@@ -109,7 +106,7 @@ yasui.createServer({
     info: {
       title: 'Mi API',
       version: '1.0.0',
-      description: 'Documentación API'
+      description: 'Documentación de API'
     }
   }
 });
@@ -117,7 +114,7 @@ yasui.createServer({
 
 #### `enableDecoratorValidation`
 **Tipo:** `boolean`  
-**Por defecto:** `true`  
+**Valor Predeterminado:** `true`  
 **Descripción:** Habilita la validación de decoradores al inicio para detectar errores de configuración.
 
 ```typescript
@@ -188,9 +185,6 @@ app.listen(3000, () => {
 ### Configuración Básica de API
 
 ```typescript
-import yasui from 'yasui';
-import { UserController, AuthController } from './controllers';
-
 yasui.createServer({
   controllers: [UserController, AuthController],
   port: 3000,
@@ -201,10 +195,6 @@ yasui.createServer({
 ### Configuración Completa
 
 ```typescript
-import yasui from 'yasui';
-import { UserController, AuthController } from './controllers';
-import { AuthMiddleware, LoggingMiddleware } from './middleware';
-
 yasui.createServer({
   controllers: [UserController, AuthController],
   middlewares: [LoggingMiddleware, AuthMiddleware],
@@ -263,9 +253,9 @@ app.listen(PORT, () => {
 });
 ```
 
-## Modo Debug
+## Modo de Depuración
 
-Habilita el modo debug para ver información detallada:
+Habilita el modo de depuración para ver información detallada:
 
 ```typescript
 yasui.createServer({
@@ -274,7 +264,7 @@ yasui.createServer({
 });
 ```
 
-El modo debug proporciona:
+El modo de depuración proporciona:
 - Registro de peticiones/respuestas
 - Detalles de inyección de dependencias
 - Información de registro de rutas

--- a/docs/es/reference/dependency-injection.md
+++ b/docs/es/reference/dependency-injection.md
@@ -51,14 +51,14 @@ export class UserService {
 export class EmailService {
   sendEmail(to: string, subject: string) {
     // Lógica de email aquí
-    console.log(`Sending email to ${to}: ${subject}`);
+    console.log(`Enviando email a ${to}: ${subject}`);
   }
 }
 ```
 
 ## Inyección en el Constructor
 
-Simplemente declara tus dependencias en controladores, middleware o constructores de servicios. Puedes inyectar múltiples servicios en el mismo constructor. Se resolverán e inyectarán automáticamente:
+Simplemente declara tus dependencias en controladores, middleware o constructores de servicios. Puedes inyectar múltiples servicios en el mismo constructor. Serán resueltos e inyectados automáticamente:
 
 ```typescript
 @Injectable()
@@ -72,7 +72,7 @@ export class OrderService {
   processOrder(orderData: any) {
     const user = this.userService.getUser(orderData.userId);
     const payment = this.paymentService.processPayment(orderData.amount);
-    this.emailService.sendEmail(user.email, 'Order confirmed');
+    this.emailService.sendEmail(user.email, 'Pedido confirmado');
     
     return { order: orderData, payment };
   }
@@ -83,11 +83,11 @@ export class OrderService {
 
 ### Decorador Scope
 
-- `@Scope(scope)` - Especifica el ámbito de dependencia (parámetro de ámbito requerido)
+- `@Scope(scope)` - Especifica el ámbito de dependencia (parámetro scope requerido)
 
-YasuiJS soporta tres ámbitos diferentes de dependencia que controlan cómo se crean y comparten las instancias:
+YasuiJS soporta tres diferentes ámbitos de dependencia que controlan cómo se crean y comparten las instancias:
 
-- **`Scopes.SHARED`** (predeterminado): Instancia singleton compartida en toda la aplicación
+- **`Scopes.SHARED`** (por defecto): Instancia singleton compartida en toda la aplicación
 - **`Scopes.LOCAL`**: Nueva instancia para cada contexto de inyección
 - **`Scopes.DEEP_LOCAL`**: Nueva instancia que propaga la localidad a sus propias dependencias
 
@@ -125,7 +125,9 @@ Puedes inyectar dependencias directamente en parámetros de método de controlad
 ```typescript
 @Controller('/users')
 export class UserController {
-  constructor(private userService: UserService) {} // Instancia compartida para el controlador
+
+  // Instancia compartida para el controlador
+  constructor(private userService: UserService) {}
 
   @Get('/:id')
   getUser(
@@ -133,11 +135,6 @@ export class UserController {
     @Inject() userService: UserService // Instancia específica para este endpoint
   ) {
     return userService.getUser(id);
-  }
-
-  @Get('/')
-  getUsers(@Inject() userService: UserService) {
-    return userService.getAllUsers();
   }
 }
 ```
@@ -161,9 +158,9 @@ export class ApiController {
 
 ## Tokens de Inyección Personalizados
 
-### Uso de Tokens Personalizados
+### Usando Tokens Personalizados
 
-Para escenarios complejos, usa tokens de inyección personalizados con `@Inject()`. Esto es útil para inyectar valores primitivos, configuraciones o cuando necesitas múltiples instancias de la misma clase:
+Para escenarios complejos, usa tokens de inyección personalizados con `@Inject()`. Esto es útil para inyectar valores primitivos, configuraciones, o cuando necesitas múltiples instancias de la misma clase:
 
 ```typescript
 @Injectable()
@@ -172,7 +169,7 @@ export class DatabaseService {
     @Inject('DATABASE_URL') private dbUrl: string,
     @Inject('CONFIG') private config: AppConfig
   ) {
-    console.log(`Connecting to: ${this.dbUrl}`);
+    console.log(`Conectando a: ${this.dbUrl}`);
   }
 }
 
@@ -191,9 +188,9 @@ export class UserController {
 }
 ```
 
-### Registro de Tokens Personalizados
+### Registrando Tokens Personalizados
 
-Registra tokens personalizados en la configuración de tu aplicación:
+Registra tokens personalizados en tu configuración de aplicación:
 
 ```typescript
 interface AppConfig {

--- a/docs/es/reference/swagger.md
+++ b/docs/es/reference/swagger.md
@@ -6,7 +6,7 @@ YasuiJS proporciona generación de documentación OpenAPI con integración opcio
 
 ### Configuración Básica
 
-Habilita Swagger agregando configuración a tu aplicación. YasuiJS genera automáticamente documentación de tus controladores, rutas y decoradores.
+Habilita Swagger agregando configuración a tu aplicación. YasuiJS genera documentación a partir de tus controladores, rutas y decoradores.
 
 **Nota**: Necesitas instalar `swagger-ui-express` por separado:
 ```bash
@@ -16,17 +16,18 @@ npm install swagger-ui-express
 ```typescript
 yasui.createServer({
   controllers: [UserController],
-  swagger: {
-    enabled: true,
-    info: {
-      title: 'Mi API',
-      version: '1.0.0'
-    }
-  }
+  swagger: { enabled: true }
 });
 ```
 
-La documentación estará accesible en `/api-docs` (ruta predeterminada) y la especificación JSON en `/api-docs.json`.
+La documentación será accesible en `/api-docs` (ruta predeterminada) y la especificación JSON en `/api-docs/swagger.json`.
+
+YasuiJS genera automáticamente documentación básica a partir de tus controladores y decoradores de ruta existentes, incluso sin decoradores específicos de Swagger. El framework detecta:
+- **Parámetros**: Los parámetros de ruta, parámetros de consulta y encabezados se detectan automáticamente con tipo `string` por defecto
+- **Cuerpo de la solicitud**: Se detecta automáticamente cuando está presente con esquema `{}` por defecto
+- **Respuestas**: Solo se detecta el código de estado 200 (o el estado predeterminado si `@HttpStatus` está presente) sin información de esquema
+
+Las siguientes secciones describen cómo mejorar esta documentación con metadatos adicionales y tipado preciso.
 
 ### Configuración Completa
 
@@ -35,176 +36,187 @@ yasui.createServer({
   controllers: [UserController],
   swagger: {
     enabled: true,
-    path: '/docs', // Ruta personalizada
+    path: '/docs', // Ruta personalizada, especificación JSON en `/docs/swagger.json`
     info: {
       title: 'API de Gestión de Usuarios',
       version: '2.1.0',
       description: 'API completa para operaciones de gestión de usuarios',
-      contact: {
-        name: 'Soporte API',
-        email: 'support@example.com'
-      },
-      license: {
-        name: 'MIT',
-        url: 'https://opensource.org/licenses/MIT'
-      }
     },
-    servers: [
-      {
-        url: 'https://api.example.com/v1',
-        description: 'Servidor de producción'
-      },
-      {
-        url: 'http://localhost:3000',
-        description: 'Servidor de desarrollo'
-      }
-    ]
   }
 });
 ```
 
-## Documentación Mejorada
+## Definición de Esquema
 
-Enriquece la documentación API predeterminada con decoradores opcionales. Todos los decoradores se adjuntan al método del endpoint:
+YasuiJS utiliza clases TypeScript con decoradores de propiedades para definir esquemas de API. Las propiedades se infieren automáticamente de los metadatos de TypeScript cuando se usan decoradores sin parámetros.
 
-### Operación API
+Los esquemas se registran automáticamente si se utilizan en cualquier decorador.
 
-- `@ApiOperation(summary, description?, tags?)` - Describe el endpoint
+### `@ApiProperty(definition?)`
+Define una propiedad, requerida por defecto. Admite múltiples formatos de definición:
 
 ```typescript
-import { ApiOperation } from 'yasui';
+export class CreateUserDto {
+  @ApiProperty() // Tipo inferido de TypeScript
+  name: string;
 
-@Controller('/users')
-export class UserController {
-  @Get('/')
-  @ApiOperation('Obtener todos los usuarios', 'Recuperar una lista de todos los usuarios en el sistema', ['usuarios'])
-  getUsers() {
-    return this.userService.getAllUsers();
-  }
+  @ApiProperty({ type: 'string', format: 'email' }) // Esquema OpenAPI, personalización completa
+  username: string;
 
-  @Post('/')
-  @ApiOperation('Crear usuario', 'Crear una nueva cuenta de usuario')
-  createUser(@Body() userData: any) {
-    return this.userService.createUser(userData);
-  }
+  @ApiProperty({ enum: ['admin', 'user', 'moderator'] }) // Valores enum
+  role: string;
+
+  @ApiProperty({ enum: UserStatus }) // Enum de TypeScript
+  status: UserStatus;
+
+  @ApiProperty([String]) // Array de primitivos
+  tags: string[];
+
+  @ApiProperty(AddressDto) // Referencia a otra clase
+  address: AddressDto;
+
+  @ApiProperty([AddressDto]) // Array de referencias de clase
+  previousAddresses: AddressDto[];
+
+  @ApiProperty({
+    theme: String,
+    preferences: PreferencesDto,
+    categories: [String],
+    addresses: [AddressDto]
+  }) // Registro de usos previamente listados
+  settings: any;
 }
+```
+
+Solo los tipos primitivos pueden ser inferidos de los metadatos de TypeScript. Los tipos complejos (incluyendo arrays) tendrán por defecto `{ type: 'object' }`. Para tipado específico, usa los formatos de definición explícitos mostrados arriba.
+
+### `@ApiPropertyOptional(definition?)`
+Equivalente a `@ApiProperty({ required: false })`
+
+```typescript
+@ApiPropertyOptional()
+description?: string;
+
+@ApiPropertyOptional({ enum: ['small', 'medium', 'large'] })
+size?: string;
+```
+
+### `@ApiSchema(name)`
+Define un nombre de esquema personalizado. El nombre predeterminado es el nombre de la clase. Los nombres de esquema deben ser únicos.
+
+```typescript
+@ApiSchema('Solicitud de Crear Usuario')
+export class CreateUserDto {
+  @ApiProperty()
+  name: string;
+}
+```
+
+### Alias
+- `@AP()` - Alias para `@ApiProperty()`
+- `@APO()` - Alias para `@ApiPropertyOptional()`
+
+## Documentación de Endpoints
+
+### `@ApiBody(description?, definition?, contentType?)`
+Documenta el esquema del cuerpo de la solicitud. El tipo de contenido predeterminado es `application/json`.
+
+```typescript
+@Post('/users')
+@ApiBody('Datos del usuario', CreateUserDto)
+createUser(@Body() data: CreateUserDto) {}
+```
+Todos los formatos de definición descritos para @ApiProperty (esquema OpenAPI, Array de primitivos, Array de referencias de clase, Record, Enum...) son válidos para @ApiBody. Los esquemas de cualquier clase se resolverán automáticamente.
+
+También es posible usar @ApiBody solo con referencia de clase sin descripción (será el nombre del esquema en este caso).
+```ts
+@Post('/users')
+@ApiBody(CreateUserDto)
+createUser(@Body() data: CreateUserDto) {}
+```
+
+### `@ApiResponse(statusCode, description?, definition?)`
+Documenta las respuestas del endpoint.
+
+```typescript
+@Get('/users')
+@ApiResponse(200, 'Usuarios', [UserDto])
+getUsers() {}
+```
+Todos los formatos de definición descritos para @ApiProperty (esquema OpenAPI, Array de primitivos, Array de referencias de clase, Record, Enum...) son válidos para @ApiResponse. Los esquemas de cualquier clase se resolverán automáticamente.
+
+También es posible usar @ApiResponse solo con referencia de clase sin descripción (será el nombre del esquema en este caso).
+```typescript
+@Get('/users/:id')
+@ApiResponse(200, UserDto)
+getUser(@Param('id') id: string) {}
+```
+
+### `@ApiOperation(summary, description?, tags?)`
+Describe la operación del endpoint.
+
+```typescript
+@Get('/users')
+@ApiOperation('Obtener todos los usuarios')
+getUsers() {}
+
+@Post('/users')
+@ApiOperation('Crear usuario', 'Crea una nueva cuenta de usuario', ['usuarios'])
+createUser() {}
 ```
 
 ### Documentación de Parámetros
+- `@ApiParam(name, description?, required?, definition?)` - Parámetros de ruta
+- `@ApiQuery(name, description?, required?, definition?)` - Parámetros de consulta
+- `@ApiHeader(name, description?, required?, definition?)` - Encabezados
 
-- `@ApiParam(name, description?, required?, schema?)` - Documenta parámetros de ruta
-- `@ApiQuery(name, description?, required?, schema?)` - Documenta parámetros de consulta
-- `@ApiHeader(name, description?, required?, schema?)` - Documenta encabezados
-
-```typescript
-import { ApiParam, ApiQuery, ApiHeader } from 'yasui';
-
-@Controller('/users')
-export class UserController {
-  @Get('/:id')
-  @ApiParam('id', 'Identificador único del usuario', true, { type: 'string' })
-  @ApiHeader('Authorization', 'Token Bearer para autenticación', true)
-  getUser(@Param('id') id: string) {
-    return this.userService.findById(id);
-  }
-
-  @Get('/')
-  @ApiQuery('page', 'Número de página para paginación', false, { type: 'number', default: 1 })
-  @ApiQuery('limit', 'Número de elementos por página', false, { type: 'number', default: 10 })
-  getUsers(
-    @Query('page') page: number = 1,
-    @Query('limit') limit: number = 10
-  ) {
-    return this.userService.getUsers({ page, limit });
-  }
-}
-```
-
-### Documentación del Cuerpo de la Solicitud
-
-- `@ApiBody(description?, schema?)` - Documenta el cuerpo de la solicitud
+Todos los formatos de definición descritos para `@ApiProperty` y decoradores anteriores son compatibles, pero ten en cuenta que los usos complejos (objetos, arrays, referencias de clase, etc.) pueden no tener sentido según la naturaleza del decorador, aunque el esquema OpenAPI se generará correctamente.
 
 ```typescript
-import { ApiBody } from 'yasui';
-
-@Controller('/users')
-export class UserController {
-  @Post('/')
-  @ApiBody('Datos de creación de usuario', {
-    type: 'object',
-    properties: {
-      name: { type: 'string', description: 'Nombre completo del usuario' },
-      email: { type: 'string', format: 'email', description: 'Dirección de correo electrónico del usuario' },
-      age: { type: 'number', minimum: 18, description: 'Edad del usuario (debe ser mayor de 18)' }
-    },
-    required: ['name', 'email']
-  })
-  createUser(@Body() userData: any) {
-    return this.userService.createUser(userData);
-  }
-}
-```
-
-### Documentación de Respuestas
-
-- `@ApiResponse(statusCode, description, schema?)` - Documenta respuestas
-
-```typescript
-import { ApiResponse } from 'yasui';
-
-@Controller('/users')
-export class UserController {
-  @Get('/:id')
-  @ApiResponse(200, 'Usuario encontrado exitosamente', {
-    type: 'object',
-    properties: {
-      id: { type: 'string' },
-      name: { type: 'string' },
-      email: { type: 'string' },
-      createdAt: { type: 'string', format: 'date-time' }
-    }
-  })
-  @ApiResponse(404, 'Usuario no encontrado')
-  getUser(@Param('id') id: string) {
-    return this.userService.findById(id);
-  }
-
-  @Post('/')
-  @ApiResponse(201, 'Usuario creado exitosamente')
-  @ApiResponse(400, 'Datos de usuario inválidos')
-  createUser(@Body() userData: any) {
-    return this.userService.createUser(userData);
-  }
-}
+@Get('/users/:id')
+@ApiParam('id', 'ID del usuario', true, Number)
+@ApiQuery('include', 'Incluir datos relacionados', false, Boolean)
+@ApiHeader('Authorization', 'Token Bearer', true) // String por defecto
+getUser(
+  @Param('id') id: number,
+  @Query('include') include?: boolean
+) {}
 ```
 
 ## Respuestas de Error
 
-`ErrorResourceSchema` genera un esquema para el formato de envoltorio de error de YasuiJS. Opcionalmente puedes definir campos adicionales que se incluirán en la propiedad `data` para tus errores personalizados:
+### `@ApiErrorResponse(statusCode, description?, ErrorDataClass?)`
+Documenta respuestas de error con el formato del envoltorio de error de YasuiJS. Este decorador incluye automáticamente la estructura completa del esquema de error del framework que envuelve todos los errores en tu aplicación.
 
 ```typescript
-import { ApiResponse, ErrorResourceSchema } from 'yasui';
+@Get('/users/:id')
+@ApiErrorResponse(404, 'Usuario no encontrado')
+@ApiErrorResponse(500, 'Error interno del servidor')
+getUser(@Param('id') id: string) {}
+```
 
-@Controller('/users')
-export class UserController {
-  @Get('/:id')
-  @ApiResponse(404, 'Usuario no encontrado', ErrorResourceSchema())
-  getUser(@Param('id') id: string) {
-    return this.userService.findById(id);
-  }
+Cuando tienes clases de error personalizadas que extienden `HttpError`, puedes mejorarlas con los decoradores `@ApiProperty` y `@ApiPropertyOptional` para documentar sus propiedades específicas. El esquema resultante combinará tus datos de error personalizados con el envoltorio de error estándar de YasuiJS:
 
-  @Post('/')
-  @ApiResponse(400, 'Validación fallida', ErrorResourceSchema({
-    fields: { 
-      type: 'array', 
-      items: { type: 'string' },
-      description: 'Lista de campos inválidos' 
-    }
-  }, {
-    fields: ['email', 'password']
-  }))
-  createUser(@Body() userData: any) {
-    return this.userService.createUser(userData);
-  }
-}
+```typescript
+@Post('/users')
+@ApiErrorResponse(400, 'Fallo en la validación', ValidationErrorData)
+createUser(@Body() data: CreateUserDto) {}
+
+// También es posible solo con referencia de clase (la descripción será el nombre del esquema)
+@Post('/users')
+@ApiErrorResponse(400, ValidationErrorData)
+createUser(@Body() data: CreateUserDto) {}
+```
+
+### Enfoque alternativo
+Si prefieres una documentación de errores más simple sin el formato completo del envoltorio, puedes continuar usando el decorador estándar `@ApiResponse` descrito anteriormente. Con `@ApiResponse`, si pasas una clase de error personalizada que extiende HttpError, solo obtendrás el esquema de esa clase específica sin heredar ninguna definición de API.
+
+## Funciones de Utilidad
+
+### `resolveSchema(schema: ApiPropertyDefinition): OpenAPISchema`
+Resuelve manualmente cualquier definición de esquema (ver formatos descritos en la sección @ApiProperty) al formato OpenAPI. Útil para casos de uso específicos.
+
+```typescript
+import { resolveSchema } from 'yasui';
+const schema = resolveSchema(CreateUserDto);
 ```

--- a/docs/fr/guide/getting-started.md
+++ b/docs/fr/guide/getting-started.md
@@ -95,10 +95,6 @@ Visitez `http://localhost:3000` et vous verrez :
 
 Félicitations ! Vous avez une API YasuiJS fonctionnelle.
 
-## Exemples
-
-Consultez les [exemples complets](https://github.com/thomasbarkats/yasui/tree/main/src/examples) dans le dépôt YasuiJS pour plus de modèles et de cas d'utilisation.
-
 ## Besoin d'aide ?
 
 Si vous rencontrez des problèmes :

--- a/docs/fr/reference/config.md
+++ b/docs/fr/reference/config.md
@@ -2,12 +2,12 @@
 
 Référence complète de configuration pour les applications YasuiJS utilisant `yasui.createServer()` et `yasui.createApp()`.
 
-## Aperçu
+## Vue d'ensemble
 
-YasuiJS propose deux méthodes principales pour créer votre application :
+YasuiJS propose deux façons principales de créer votre application :
 
-- **`yasui.createServer(config)`** - Crée et démarre automatiquement un serveur HTTP
-- **`yasui.createApp(config)`** - Renvoie une application Express pour une configuration manuelle
+- **`yasui.createServer(config)`** - Crée et démarre un serveur HTTP automatiquement
+- **`yasui.createApp(config)`** - Retourne une application Express pour une configuration manuelle
 
 Les deux méthodes acceptent le même objet de configuration avec les options suivantes.
 
@@ -20,7 +20,7 @@ Les deux méthodes acceptent le même objet de configuration avec les options su
 **Description:** Tableau des classes de contrôleurs à enregistrer dans votre application.
 
 ```typescript
-import { UserController, ProductController } from './controllers';
+import yasui from 'yasui';
 
 yasui.createServer({
   controllers: [UserController, ProductController]
@@ -31,13 +31,10 @@ yasui.createServer({
 
 #### `middlewares`
 **Type:** `Array<Constructor | RequestHandler>`  
-**Défaut:** `[]`  
-**Description:** Tableau de middlewares globaux à appliquer à toutes les requêtes. Peut être des classes middleware YasuiJS ou des fonctions RequestHandler Express.
+**Default:** `[]`  
+**Description:** Tableau des middlewares globaux à appliquer à toutes les requêtes. Peut être des classes middleware YasuiJS ou des fonctions RequestHandler Express.
 
 ```typescript
-import { LoggingMiddleware } from './middleware';
-import cors from 'cors';
-
 yasui.createServer({
   controllers: [UserController],
   middlewares: [LoggingMiddleware, cors()]
@@ -46,7 +43,7 @@ yasui.createServer({
 
 #### `environment`
 **Type:** `string`  
-**Défaut:** `process.env.NODE_ENV || 'development'`  
+**Default:** `process.env.NODE_ENV || 'development'`  
 **Description:** Nom de l'environnement pour votre application.
 
 ```typescript
@@ -58,7 +55,7 @@ yasui.createServer({
 
 #### `port`
 **Type:** `number`  
-**Défaut:** `3000`  
+**Default:** `3000`  
 **Description:** Numéro de port pour le serveur HTTP. Utilisé uniquement avec `createServer()`.
 
 ```typescript
@@ -70,8 +67,8 @@ yasui.createServer({
 
 #### `debug`
 **Type:** `boolean`  
-**Défaut:** `false`  
-**Description:** Active le mode débogage avec journalisation supplémentaire et traçage des requêtes.
+**Default:** `false`  
+**Description:** Active le mode debug avec des logs supplémentaires et le traçage des requêtes.
 
 ```typescript
 yasui.createServer({
@@ -82,7 +79,7 @@ yasui.createServer({
 
 #### `injections`
 **Type:** `Array<{ token: string, provide: any }>`  
-**Défaut:** `[]`  
+**Default:** `[]`  
 **Description:** Jetons d'injection personnalisés pour l'injection de dépendances. Voir [Injection de Dépendances](/fr/reference/dependency-injection) pour plus de détails.
 
 ```typescript
@@ -97,7 +94,7 @@ yasui.createServer({
 
 #### `swagger`
 **Type:** `SwaggerConfig | undefined`  
-**Défaut:** `undefined`  
+**Default:** `undefined`  
 **Description:** Configuration de la documentation Swagger. Voir [Swagger](/fr/reference/swagger) pour plus de détails.
 
 ```typescript
@@ -107,9 +104,9 @@ yasui.createServer({
     enabled: true,
     path: '/api-docs',
     info: {
-      title: 'My API',
+      title: 'Mon API',
       version: '1.0.0',
-      description: 'API documentation'
+      description: 'Documentation API'
     }
   }
 });
@@ -117,7 +114,7 @@ yasui.createServer({
 
 #### `enableDecoratorValidation`
 **Type:** `boolean`  
-**Défaut:** `true`  
+**Default:** `true`  
 **Description:** Active la validation des décorateurs au démarrage pour détecter les erreurs de configuration.
 
 ```typescript
@@ -152,7 +149,7 @@ yasui.createServer({
 
 ### createApp()
 
-Renvoie une application Express pour une configuration manuelle :
+Retourne une application Express pour une configuration manuelle :
 
 ```typescript
 import yasui from 'yasui';
@@ -168,12 +165,12 @@ app.use('/health', (req, res) => {
 
 // Ajouter des routes personnalisées
 app.get('/custom', (req, res) => {
-  res.json({ message: 'Custom route' });
+  res.json({ message: 'Route personnalisée' });
 });
 
 // Démarrer le serveur manuellement
 app.listen(3000, () => {
-  console.log('Server running on port 3000');
+  console.log('Serveur en cours d\'exécution sur le port 3000');
 });
 ```
 
@@ -185,12 +182,9 @@ app.listen(3000, () => {
 
 ## Exemples de Configuration
 
-### Configuration API de Base
+### Configuration API Basique
 
 ```typescript
-import yasui from 'yasui';
-import { UserController, AuthController } from './controllers';
-
 yasui.createServer({
   controllers: [UserController, AuthController],
   port: 3000,
@@ -201,10 +195,6 @@ yasui.createServer({
 ### Configuration Complète
 
 ```typescript
-import yasui from 'yasui';
-import { UserController, AuthController } from './controllers';
-import { AuthMiddleware, LoggingMiddleware } from './middleware';
-
 yasui.createServer({
   controllers: [UserController, AuthController],
   middlewares: [LoggingMiddleware, AuthMiddleware],
@@ -220,9 +210,9 @@ yasui.createServer({
     enabled: true,
     path: '/api-docs',
     info: {
-      title: 'My API',
+      title: 'Mon API',
       version: '1.0.0',
-      description: 'Complete API with all features'
+      description: 'API complète avec toutes les fonctionnalités'
     }
   }
 });
@@ -251,21 +241,21 @@ app.get('/health', (req, res) => {
   res.json({ status: 'ok', timestamp: new Date().toISOString() });
 });
 
-// Middleware de gestion d'erreurs
+// Middleware de gestion des erreurs
 app.use((err, req, res, next) => {
   console.error(err.stack);
-  res.status(500).json({ error: 'Something went wrong!' });
+  res.status(500).json({ error: 'Quelque chose s\'est mal passé !' });
 });
 
 const PORT = process.env.PORT || 3000;
 app.listen(PORT, () => {
-  console.log(`Server running on port ${PORT}`);
+  console.log(`Serveur en cours d'exécution sur le port ${PORT}`);
 });
 ```
 
-## Mode Débogage
+## Mode Debug
 
-Activez le mode débogage pour voir des informations détaillées :
+Activez le mode debug pour voir des informations détaillées :
 
 ```typescript
 yasui.createServer({
@@ -274,8 +264,8 @@ yasui.createServer({
 });
 ```
 
-Le mode débogage fournit :
+Le mode debug fournit :
 - Journalisation des requêtes/réponses
-- Détails sur l'injection de dépendances
+- Détails de l'injection de dépendances
 - Informations sur l'enregistrement des routes
-- Traces de pile d'erreurs
+- Traces des piles d'erreurs

--- a/docs/fr/reference/controllers.md
+++ b/docs/fr/reference/controllers.md
@@ -1,12 +1,12 @@
 # Contrôleurs
 
-Les contrôleurs sont les points d'entrée de votre API. Ils définissent les points de terminaison HTTP et gèrent les requêtes entrantes en extrayant des données, en appelant la logique métier et en renvoyant des réponses.
+Les contrôleurs sont les points d'entrée de votre API. Ils définissent les points de terminaison HTTP et gèrent les requêtes entrantes en extrayant les données, en appelant la logique métier et en renvoyant les réponses.
 
-## Aperçu
+## Vue d'ensemble
 
-Dans YasuiJS, les contrôleurs sont des classes décorées avec `@Controller()` qui regroupent des points de terminaison connexes. Chaque méthode dans un contrôleur représente un point de terminaison HTTP, défini à l'aide de décorateurs de méthode comme `@Get()`, `@Post()`, etc.
+Dans YasuiJS, les contrôleurs sont des classes décorées avec `@Controller()` qui regroupent les points de terminaison associés. Chaque méthode d'un contrôleur représente un point de terminaison HTTP, défini à l'aide de décorateurs de méthode comme `@Get()`, `@Post()`, etc.
 
-Les méthodes de contrôleur peuvent simplement renvoyer n'importe quelle valeur, qui sera automatiquement sérialisée en JSON avec un code de statut 200. Pour plus de contrôle, vous pouvez accéder directement à l'objet de réponse Express en utilisant `@Res()` et utiliser des méthodes natives d'Express comme `res.json()`, `res.status()`, ou `res.sendFile()`.
+Les méthodes du contrôleur peuvent simplement renvoyer n'importe quelle valeur, qui sera automatiquement sérialisée en JSON avec un code d'état 200. Pour plus de contrôle, vous pouvez accéder directement à l'objet de réponse Express en utilisant `@Res()` et utiliser les méthodes natives Express comme `res.json()`, `res.status()`, ou `res.sendFile()`.
 
 ```typescript
 import { Controller, Get, Post } from 'yasui';
@@ -16,11 +16,6 @@ export class UserController {
   @Get('/')
   getAllUsers() {
     return { users: [] }; // Renvoie automatiquement du JSON
-  }
-
-  @Post('/')
-  createUser() {
-    return { message: 'User created' }; // Renvoie automatiquement du JSON
   }
 }
 ```
@@ -40,11 +35,9 @@ export class UserController {
 
 ### Avec Middleware
 
-Vous pouvez appliquer des middlewares à toutes les routes d'un contrôleur. En savoir plus dans [Middlewares](/fr/reference/middlewares).
+Vous pouvez appliquer un middleware à toutes les routes d'un contrôleur. En savoir plus dans [Middlewares](/fr/reference/middlewares).
 
 ```typescript
-import { AuthMiddleware } from './middleware/auth.middleware';
-
 @Controller('/api/users', AuthMiddleware)
 export class UserController {
   // Toutes les routes auront AuthMiddleware appliqué
@@ -53,7 +46,7 @@ export class UserController {
 
 ## Décorateurs de méthodes HTTP
 
-YasuiJS fournit des décorateurs pour toutes les méthodes HTTP standard. Chaque décorateur prend un paramètre de chemin (obligatoire) et des paramètres de middleware optionnels.
+YasuiJS fournit des décorateurs pour toutes les méthodes HTTP standard. Chaque décorateur prend un paramètre de chemin (obligatoire) et des paramètres middleware optionnels.
 
 - `@Get(path, ...middlewares)` - Gère les requêtes GET
 - `@Post(path, ...middlewares)` - Gère les requêtes POST
@@ -71,87 +64,126 @@ export class UserController {
     return { users: [] };
   }
 
-  @Get('/:id')
-  getUser() {
-    return { user: {} };
-  }
-
   @Post('/')
   createUser() {
-    return { message: 'User created' };
+    return { message: 'Utilisateur créé' };
+  }
+
+  @Get('/:id')
+  getUser() {
+    // Utilisez les paramètres de route de style Express dans vos chemins :
+    // Route: GET /api/users/123
+    return { user: {} };
   }
 
   @Put('/:id')
   updateUser() {
-    return { message: 'User updated' };
+    return { message: 'Utilisateur mis à jour' };
   }
 
   @Delete('/:id')
   deleteUser() {
-    return { message: 'User deleted' };
+    return { message: 'Utilisateur supprimé' };
   }
 }
 ```
 
-### Paramètres de route
+### Middleware au niveau des routes
 
-Utilisez des paramètres de route de style Express dans vos chemins :
-
-```typescript
-@Controller('/api/users')
-export class UserController {
-  @Get('/:id')
-  getUser() {
-    // Route: GET /api/users/123
-  }
-
-  @Get('/:id/posts/:postId')
-  getUserPost() {
-    // Route: GET /api/users/123/posts/456
-  }
-
-  @Get('/search/:category?')
-  searchUsers() {
-    // Route: GET /api/users/search ou /api/users/search/admin
-  }
-}
-```
-
-### Middleware au niveau de la route
-
-Appliquez des middlewares à des routes spécifiques. En savoir plus dans [Middlewares](/fr/reference/middlewares).
+Appliquez un middleware à des routes spécifiques. En savoir plus dans [Middlewares](/fr/reference/middlewares).
 
 ```typescript
-import { ValidationMiddleware, AuthMiddleware } from './middleware';
-
 @Controller('/api/users')
 export class UserController {
   @Get('/', ValidationMiddleware)
-  getAllUsers() {
-    // Seule cette route a ValidationMiddleware
-  }
-
-  @Post('/', AuthMiddleware, ValidationMiddleware)
-  createUser() {
-    // Cette route a les deux middlewares
-  }
+  getAllUsers() {}
 }
 ```
 
 ## Décorateurs de paramètres
 
-Extrayez des données des requêtes HTTP à l'aide de décorateurs de paramètres. Tous les décorateurs de paramètres peuvent être utilisés avec ou sans nom de paramètre pour extraire des valeurs spécifiques ou des objets entiers.
+Extrayez des données des requêtes HTTP à l'aide de décorateurs de paramètres. YasuiJS transforme automatiquement les paramètres en fonction de leurs types TypeScript pour une meilleure sécurité des types.
+
+### Extraire le corps de la requête
+
+- `@Body(name?)` - Extraire les données du corps de la requête
+
+```typescript
+@Controller('/api/users')
+export class UserController {
+  @Post('/')
+  createUser(@Body() userData: any) {
+    // Extraire tout le corps de la requête
+    return { created: userData };
+  }
+
+  @Post('/partial')
+  updateUser(@Body('name') name: string) {
+    // Extraire un champ spécifique du corps
+    return { updatedName: name };
+  }
+}
+```
+
+### Extraire les paramètres et les en-têtes
+
+- `@Param(name)` - Extraire les paramètres de route
+- `@Query(name)` - Extraire les paramètres de requête
+- `@Header(name?)` - Extraire les en-têtes de requête
+
+Les paramètres sont automatiquement transformés en fonction de leurs types TypeScript :
+
+```typescript
+@Controller('/api/users')
+export class UserController {
+  @Get('/:id')
+  getUser(@Param('id') id: number) { 
+    // Automatiquement converti en nombre
+  }
+
+  @Get('/search')
+  searchUsers(
+    @Query('page') page: number,
+    @Query('active') active: boolean,
+    @Query('tags') tags: string[]
+  ) {
+    // page: number (converti de "123" à 123)
+    // active: boolean (converti de "true"/"1" à true)
+    // tags: string[] (de ?tags=red&tags=blue)
+    return { page, active, tags };
+  }
+
+  @Get('/profile')
+  getProfile(
+    @Query('settings') settings: { theme: string },
+    @Header('x-api-version') version: number
+  ) {
+    // settings: object (de ?settings={"theme":"dark"} - JSON analysé)
+    // version: number (en-tête converti en nombre)
+    return { settings, version };
+  }
+}
+```
+
+### Transformations de types prises en charge
+
+YasuiJS convertit automatiquement les paramètres en fonction des types TypeScript :
+
+- **string** - Pas de conversion (par défaut)
+- **number** - Convertit en nombre, renvoie NaN si invalide
+- **boolean** - Convertit "true"/"1" en true, tout le reste en false
+- **Date** - Convertit en objet Date, renvoie Invalid Date si invalide
+- **string[]** - Pour les tableaux de requête comme `?tags=red&tags=blue`
+- **object** - Analyse les chaînes JSON pour les requêtes comme `?data={"key":"value"}`
 
 ### Accès à l'objet Request
 
-- `@Req()` - Accède à l'objet Request d'Express (pas de paramètres)
-- `@Res()` - Accède à l'objet Response d'Express (pas de paramètres)
-- `@Next()` - Accède à la fonction NextFunction d'Express (pas de paramètres)
-
-Accédez aux objets request, response et next d'Express :
+- `@Req()` - Accéder à l'objet Request Express
+- `@Res()` - Accéder à l'objet Response Express
+- `@Next()` - Accéder à la fonction NextFunction Express
 
 ```typescript
-import { Request, Response, NextFunction } from 'express';
+import { Request, Response, NextFunction } from 'yasui';
 
 @Controller('/api/users')
 export class UserController {
@@ -161,112 +193,15 @@ export class UserController {
     @Res() response: Response,
     @Next() next: NextFunction
   ) {
-    // Accès direct aux objets Express
     console.log(request.url);
     return { users: [] };
   }
 }
 ```
 
-### Extraire les paramètres de route
-
-- `@Param(name?)` - Extrait les paramètres de route (nom de paramètre optionnel)
-
-```typescript
-@Controller('/api/users')
-export class UserController {
-  @Get('/:id')
-  getUser(@Param('id') id: string) {
-    // Extrait un paramètre spécifique
-    return { userId: id };
-  }
-
-  @Get('/:id/posts/:postId')
-  getUserPost(
-    @Param('id') userId: string,
-    @Param('postId') postId: string
-  ) {
-    // Extrait plusieurs paramètres
-    return { userId, postId };
-  }
-
-  @Get('/all')
-  getAllWithParams(@Param() params: any) {
-    // Obtient tous les paramètres de route sous forme d'objet
-    return { params };
-  }
-}
-```
-
-### Extraire les paramètres de requête
-
-- `@Query(name?)` - Extrait les paramètres de requête (nom de paramètre optionnel)
-
-```typescript
-@Controller('/api/users')
-export class UserController {
-  @Get('/')
-  getUsers(
-    @Query('page') page: number = 1,
-    @Query('limit') limit: number = 10
-  ) {
-    // Extrait des paramètres de requête spécifiques avec valeurs par défaut
-    return { page, limit };
-  }
-
-  @Get('/search')
-  searchUsers(@Query() query: any) {
-    // Obtient tous les paramètres de requête sous forme d'objet
-    return { searchParams: query };
-  }
-}
-```
-
-### Extraire le corps de la requête
-
-- `@Body(name?)` - Extrait les données du corps de la requête (nom de paramètre optionnel)
-
-```typescript
-@Controller('/api/users')
-export class UserController {
-  @Post('/')
-  createUser(@Body() userData: any) {
-    // Extrait l'ensemble du corps de la requête
-    return { created: userData };
-  }
-
-  @Post('/partial')
-  updateUser(@Body('name') name: string) {
-    // Extrait un champ spécifique du corps
-    return { updatedName: name };
-  }
-}
-```
-
-### Extraire les en-têtes
-
-- `@Header(name?)` - Extrait les en-têtes de requête (nom de paramètre optionnel)
-
-```typescript
-@Controller('/api/users')
-export class UserController {
-  @Get('/')
-  getUsers(@Header('authorization') auth: string) {
-    // Extrait un en-tête spécifique
-    return { authHeader: auth };
-  }
-
-  @Get('/all-headers')
-  getUsersWithHeaders(@Header() headers: any) {
-    // Obtient tous les en-têtes sous forme d'objet
-    return { headers };
-  }
-}
-```
-
 ## Gestion des réponses
 
-YasuiJS gère automatiquement la sérialisation des réponses et les codes de statut.
+YasuiJS gère automatiquement la sérialisation des réponses et les codes d'état.
 
 ### Réponses JSON automatiques
 
@@ -283,38 +218,31 @@ export class UserController {
 
   @Get('/string')
   getString() {
-    // Renvoie une chaîne sous forme de JSON
-    return 'Hello World';
+    // Renvoie une chaîne en JSON
+    return 'Bonjour le monde';
   }
 
   @Get('/number')
   getNumber() {
-    // Renvoie un nombre sous forme de JSON
+    // Renvoie un nombre en JSON
     return 42;
   }
 }
 ```
 
-### Codes de statut personnalisés
+### Codes d'état personnalisés
 
-- `@HttpStatus(code)` - Définit un code de statut HTTP personnalisé (paramètre de code de statut requis, accepte un nombre ou l'énumération HttpCode)
+- `@HttpStatus(code)` - Définir un code d'état HTTP personnalisé
 
-Utilisez le décorateur `@HttpStatus()` pour définir des codes de statut personnalisés :
+Utilisez le décorateur `@HttpStatus()` pour définir des codes d'état personnalisés :
 
 ```typescript
 import { HttpStatus, HttpCode } from 'yasui';
 
 @Controller('/api/users')
 export class UserController {
-  @Post('/')
-  @HttpStatus(201) // Utilisation d'un nombre
-  createUser(@Body() userData: any) {
-    // Renvoie avec le statut 201 Created
-    return { created: userData };
-  }
-
   @Post('/alt')
-  @HttpStatus(HttpCode.CREATED) // Utilisation de l'énumération HttpCode
+  @HttpStatus(201) // Utilisation d'un nombre
   createUserAlt(@Body() userData: any) {
     // Renvoie avec le statut 201 Created
     return { created: userData };
@@ -331,48 +259,24 @@ export class UserController {
 
 ### Gestion manuelle des réponses
 
-Pour un contrôle complet, utilisez l'objet response d'Express :
+Pour un contrôle complet, utilisez l'objet de réponse Express :
 
 ```typescript
-import { Response } from 'express';
+import { Response } from 'yasui';
 
 @Controller('/api/users')
 export class UserController {
   @Get('/custom')
   customResponse(@Res() res: Response) {
     res.status(418).json({ 
-      message: "I'm a teapot",
+      message: "Je suis une théière",
       custom: true 
     });
-    // Ne renvoyez rien lorsque vous utilisez res directement
-  }
-
-  @Get('/file')
-  downloadFile(@Res() res: Response) {
-    res.download('/path/to/file.pdf');
+    // Ne rien renvoyer lors de l'utilisation directe de res
   }
 }
 ```
 
 ## Gestion des erreurs
 
-Laissez le framework gérer automatiquement les erreurs ou lancez des erreurs personnalisées. Pour des détails complets sur la gestion des erreurs, voir [Gestion des erreurs](/fr/reference/error-handling).
-
-```typescript
-import { HttpError, HttpCode } from 'yasui';
-
-@Controller('/api/users')
-export class UserController {
-  @Get('/:id')
-  getUser(@Param('id') id: string) {
-    const user = this.userService.findById(id);
-    
-    if (!user) {
-      // Lance une erreur HTTP personnalisée
-      throw new HttpError(HttpCode.NOT_FOUND, 'User not found');
-    }
-    
-    return user;
-  }
-}
-```
+Laissez le framework gérer automatiquement les erreurs ou lancez des erreurs personnalisées. Pour plus de détails sur la gestion des erreurs, voir [Gestion des erreurs](/fr/reference/error-handling).

--- a/docs/fr/reference/dependency-injection.md
+++ b/docs/fr/reference/dependency-injection.md
@@ -32,7 +32,7 @@ export class UserController {
 
 ### Décorateur Injectable
 
-- `@Injectable()` - Marque une classe comme injectable (pas de paramètres, requis pour tous les services)
+- `@Injectable()` - Marquer une classe comme injectable (pas de paramètres, requis pour tous les services)
 
 Utilisez le décorateur `@Injectable()` pour marquer une classe comme injectable. Ce décorateur est **requis** pour tous les services qui seront injectés.
 
@@ -83,7 +83,7 @@ export class OrderService {
 
 ### Décorateur Scope
 
-- `@Scope(scope)` - Spécifie la portée de la dépendance (paramètre de portée requis)
+- `@Scope(scope)` - Spécifier la portée de la dépendance (paramètre de portée requis)
 
 YasuiJS prend en charge trois portées différentes qui contrôlent comment les instances sont créées et partagées :
 
@@ -93,7 +93,7 @@ YasuiJS prend en charge trois portées différentes qui contrôlent comment les 
 
 Le décorateur `@Scope()` est appliqué au point d'injection, pas sur la classe de service elle-même.
 
-### Portées au niveau du constructeur
+### Portées au niveau du Constructeur
 
 Vous pouvez spécifier des portées pour des dépendances individuelles dans les constructeurs :
 
@@ -108,41 +108,38 @@ export class MyService {
 }
 ```
 
-### Directives de sélection de portée
+### Directives de Sélection de Portée
 
-- **SHARED** : Utilisez pour les services sans état, les caches, les connexions de base de données
-- **LOCAL** : Utilisez pour les services spécifiques aux requêtes, les processeurs temporaires
-- **DEEP_LOCAL** : Utilisez pour les opérations complètement isolées, les scénarios de test
+- **SHARED** : Utiliser pour les services sans état, les caches, les connexions de base de données
+- **LOCAL** : Utiliser pour les services spécifiques aux requêtes, les processeurs temporaires
+- **DEEP_LOCAL** : Utiliser pour les opérations complètement isolées, les scénarios de test
 
-## Injection au niveau des méthodes
+## Injection au niveau des Méthodes
 
 ### Décorateur Inject
 
-- `@Inject(token?)` - Injecte des dépendances dans les paramètres de méthode (token personnalisé optionnel)
+- `@Inject(token?)` - Injecter des dépendances dans les paramètres de méthode (token personnalisé optionnel)
 
-Vous pouvez injecter des dépendances directement dans les paramètres de méthode de contrôleur ou middleware. Cela limite l'injection à des points de terminaison spécifiques au lieu du contrôleur entier, permettant une gestion fine de la portée. Par exemple, vous pouvez avoir un service partagé injecté dans le constructeur, mais une route spécifique qui nécessite une instance dédiée du même service.
+Vous pouvez injecter des dépendances directement dans les paramètres de méthode des contrôleurs ou middlewares. Cela restreint l'injection à des points d'entrée spécifiques au lieu du contrôleur entier, permettant une gestion fine de la portée. Par exemple, vous pouvez avoir un service partagé injecté dans le constructeur, mais une route spécifique qui nécessite une instance dédiée du même service.
 
 ```typescript
 @Controller('/users')
 export class UserController {
-  constructor(private userService: UserService) {} // Instance partagée pour le contrôleur
+
+  // Instance partagée pour le contrôleur
+  constructor(private userService: UserService) {}
 
   @Get('/:id')
   getUser(
     @Param('id') id: string,
-    @Inject() userService: UserService // Instance spécifique à ce point de terminaison
+    @Inject() userService: UserService // Instance spécifique à ce point d'entrée
   ) {
     return userService.getUser(id);
-  }
-
-  @Get('/')
-  getUsers(@Inject() userService: UserService) {
-    return userService.getAllUsers();
   }
 }
 ```
 
-### Portées au niveau des méthodes
+### Portées au niveau des Méthodes
 
 Les portées fonctionnent également avec l'injection au niveau des méthodes :
 
@@ -159,11 +156,11 @@ export class ApiController {
 }
 ```
 
-## Tokens d'injection personnalisés
+## Tokens d'Injection Personnalisés
 
-### Utilisation de tokens personnalisés
+### Utilisation des Tokens Personnalisés
 
-Pour des scénarios complexes, utilisez des tokens d'injection personnalisés avec `@Inject()`. C'est utile pour injecter des valeurs primitives, des configurations, ou lorsque vous avez besoin de plusieurs instances de la même classe :
+Pour les scénarios complexes, utilisez des tokens d'injection personnalisés avec `@Inject()`. C'est utile pour injecter des valeurs primitives, des configurations, ou lorsque vous avez besoin de plusieurs instances de la même classe :
 
 ```typescript
 @Injectable()
@@ -191,9 +188,9 @@ export class UserController {
 }
 ```
 
-### Enregistrement des tokens personnalisés
+### Enregistrement des Tokens Personnalisés
 
-Enregistrez des tokens personnalisés dans la configuration de votre application :
+Enregistrez les tokens personnalisés dans votre configuration d'application :
 
 ```typescript
 interface AppConfig {
@@ -217,9 +214,9 @@ yasui.createServer({
 });
 ```
 
-### Dépendances circulaires
+### Dépendances Circulaires
 
-YasuiJS détecte automatiquement et empêche les dépendances circulaires au démarrage :
+YasuiJS détecte et empêche automatiquement les dépendances circulaires au démarrage :
 
 ```typescript
 // Ceci sera détecté et signalé comme une erreur

--- a/docs/zh/guide/getting-started.md
+++ b/docs/zh/guide/getting-started.md
@@ -95,10 +95,6 @@ npm run dev
 
 恭喜！您已经拥有了一个可工作的YasuiJS API。
 
-## 示例
-
-查看YasuiJS仓库中的[完整示例](https://github.com/thomasbarkats/yasui/tree/main/src/examples)，了解更多模式和用例。
-
 ## 需要帮助？
 
 如果您遇到任何问题：

--- a/docs/zh/reference/config.md
+++ b/docs/zh/reference/config.md
@@ -1,13 +1,13 @@
 # 配置
 
-YasuiJS 应用程序使用 `yasui.createServer()` 和 `yasui.createApp()` 的完整配置参考。
+使用 `yasui.createServer()` 和 `yasui.createApp()` 的 YasuiJS 应用程序完整配置参考。
 
 ## 概述
 
-YasuiJS 提供了两种主要方式来创建应用程序：
+YasuiJS 提供两种主要方式来创建应用程序：
 
 - **`yasui.createServer(config)`** - 自动创建并启动 HTTP 服务器
-- **`yasui.createApp(config)`** - 返回一个 Express 应用程序，用于手动配置
+- **`yasui.createApp(config)`** - 返回一个可手动配置的 Express 应用程序
 
 这两种方法都接受相同的配置对象，具有以下选项。
 
@@ -20,7 +20,7 @@ YasuiJS 提供了两种主要方式来创建应用程序：
 **描述:** 要在应用程序中注册的控制器类数组。
 
 ```typescript
-import { UserController, ProductController } from './controllers';
+import yasui from 'yasui';
 
 yasui.createServer({
   controllers: [UserController, ProductController]
@@ -35,9 +35,6 @@ yasui.createServer({
 **描述:** 应用于所有请求的全局中间件数组。可以是 YasuiJS 中间件类或 Express RequestHandler 函数。
 
 ```typescript
-import { LoggingMiddleware } from './middleware';
-import cors from 'cors';
-
 yasui.createServer({
   controllers: [UserController],
   middlewares: [LoggingMiddleware, cors()]
@@ -59,7 +56,7 @@ yasui.createServer({
 #### `port`
 **类型:** `number`  
 **默认值:** `3000`  
-**描述:** HTTP 服务器的端口号。仅与 `createServer()` 一起使用。
+**描述:** HTTP 服务器的端口号。仅用于 `createServer()`。
 
 ```typescript
 yasui.createServer({
@@ -83,7 +80,7 @@ yasui.createServer({
 #### `injections`
 **类型:** `Array<{ token: string, provide: any }>`  
 **默认值:** `[]`  
-**描述:** 用于依赖注入的自定义注入令牌。详情请参阅[依赖注入](/zh/reference/dependency-injection)。
+**描述:** 依赖注入的自定义注入令牌。详见 [依赖注入](/zh/reference/dependency-injection)。
 
 ```typescript
 yasui.createServer({
@@ -98,7 +95,7 @@ yasui.createServer({
 #### `swagger`
 **类型:** `SwaggerConfig | undefined`  
 **默认值:** `undefined`  
-**描述:** Swagger 文档配置。详情请参阅 [Swagger](/zh/reference/swagger)。
+**描述:** Swagger 文档配置。详见 [Swagger](/zh/reference/swagger)。
 
 ```typescript
 yasui.createServer({
@@ -118,7 +115,7 @@ yasui.createServer({
 #### `enableDecoratorValidation`
 **类型:** `boolean`  
 **默认值:** `true`  
-**描述:** 在启动时启用装饰器验证，以捕获配置错误。
+**描述:** 在启动时启用装饰器验证以捕获配置错误。
 
 ```typescript
 yasui.createServer({
@@ -127,7 +124,7 @@ yasui.createServer({
 });
 ```
 
-## createServer() 与 createApp()
+## createServer() 与 createApp() 的比较
 
 ### createServer()
 
@@ -142,17 +139,17 @@ yasui.createServer({
   debug: true
 });
 
-// 服务器自动启动并监听 3000 端口
+// 服务器自动启动并在端口 3000 上监听
 ```
 
 **适用场景：**
-- 你想立即启动服务器
-- 你不需要额外的 Express 配置
-- 你正在构建一个简单的 API
+- 想要立即启动服务器
+- 不需要额外的 Express 配置
+- 构建简单的 API
 
 ### createApp()
 
-返回一个 Express 应用程序，用于手动配置：
+返回一个可手动配置的 Express 应用程序：
 
 ```typescript
 import yasui from 'yasui';
@@ -178,19 +175,16 @@ app.listen(3000, () => {
 ```
 
 **适用场景：**
-- 你需要自定义 Express 配置
-- 你想添加自定义路由或中间件
-- 你需要更多地控制服务器启动
-- 你正在与现有的 Express 应用程序集成
+- 需要自定义 Express 配置
+- 想要添加自定义路由或中间件
+- 需要更多服务器启动控制
+- 与现有 Express 应用程序集成
 
 ## 配置示例
 
 ### 基本 API 设置
 
 ```typescript
-import yasui from 'yasui';
-import { UserController, AuthController } from './controllers';
-
 yasui.createServer({
   controllers: [UserController, AuthController],
   port: 3000,
@@ -201,10 +195,6 @@ yasui.createServer({
 ### 完整配置
 
 ```typescript
-import yasui from 'yasui';
-import { UserController, AuthController } from './controllers';
-import { AuthMiddleware, LoggingMiddleware } from './middleware';
-
 yasui.createServer({
   controllers: [UserController, AuthController],
   middlewares: [LoggingMiddleware, AuthMiddleware],

--- a/docs/zh/reference/controllers.md
+++ b/docs/zh/reference/controllers.md
@@ -1,12 +1,12 @@
 # 控制器
 
-控制器是您API的入口点。它们定义HTTP端点并通过提取数据、调用业务逻辑和返回响应来处理传入请求。
+控制器是API的入口点。它们定义HTTP端点并通过提取数据、调用业务逻辑和返回响应来处理传入请求。
 
 ## 概述
 
-在YasuiJS中，控制器是用`@Controller()`装饰的类，它们将相关端点分组在一起。控制器中的每个方法代表一个HTTP端点，使用方法装饰器如`@Get()`、`@Post()`等定义。
+在YasuiJS中，控制器是使用`@Controller()`装饰器修饰的类，用于将相关端点组合在一起。控制器中的每个方法代表一个HTTP端点，使用`@Get()`、`@Post()`等方法装饰器定义。
 
-控制器方法可以简单地返回任何值，这些值将自动序列化为JSON并带有200状态码。要获得更多控制，您可以使用`@Res()`直接访问Express响应对象，并使用原生Express方法如`res.json()`、`res.status()`或`res.sendFile()`。
+控制器方法可以简单地返回任何值，这些值将自动序列化为JSON并返回200状态码。如果需要更多控制，你可以使用`@Res()`直接访问Express响应对象，并使用原生Express方法如`res.json()`、`res.status()`或`res.sendFile()`。
 
 ```typescript
 import { Controller, Get, Post } from 'yasui';
@@ -17,17 +17,12 @@ export class UserController {
   getAllUsers() {
     return { users: [] }; // 自动返回JSON
   }
-
-  @Post('/')
-  createUser() {
-    return { message: 'User created' }; // 自动返回JSON
-  }
 }
 ```
 
 ## 控制器装饰器
 
-`@Controller()`装饰器将类标记为控制器并为其所有路由定义基本路径。
+`@Controller()`装饰器将类标记为控制器并为其所有路由定义基础路径。
 
 ### 基本用法
 
@@ -40,11 +35,9 @@ export class UserController {
 
 ### 使用中间件
 
-您可以对控制器中的所有路由应用中间件。在[中间件](/zh/reference/middlewares)中了解更多。
+你可以为控制器中的所有路由应用中间件。在[中间件](/zh/reference/middlewares)中了解更多。
 
 ```typescript
-import { AuthMiddleware } from './middleware/auth.middleware';
-
 @Controller('/api/users', AuthMiddleware)
 export class UserController {
   // 所有路由都将应用AuthMiddleware
@@ -71,48 +64,26 @@ export class UserController {
     return { users: [] };
   }
 
-  @Get('/:id')
-  getUser() {
-    return { user: {} };
-  }
-
   @Post('/')
   createUser() {
-    return { message: 'User created' };
+    return { message: '用户已创建' };
+  }
+
+  @Get('/:id')
+  getUser() {
+    // 在路径中使用Express风格的路由参数：
+    // 路由: GET /api/users/123
+    return { user: {} };
   }
 
   @Put('/:id')
   updateUser() {
-    return { message: 'User updated' };
+    return { message: '用户已更新' };
   }
 
   @Delete('/:id')
   deleteUser() {
-    return { message: 'User deleted' };
-  }
-}
-```
-
-### 路由参数
-
-在路径中使用Express风格的路由参数：
-
-```typescript
-@Controller('/api/users')
-export class UserController {
-  @Get('/:id')
-  getUser() {
-    // 路由: GET /api/users/123
-  }
-
-  @Get('/:id/posts/:postId')
-  getUserPost() {
-    // 路由: GET /api/users/123/posts/456
-  }
-
-  @Get('/search/:category?')
-  searchUsers() {
-    // 路由: GET /api/users/search 或 /api/users/search/admin
+    return { message: '用户已删除' };
   }
 }
 ```
@@ -122,109 +93,20 @@ export class UserController {
 对特定路由应用中间件。在[中间件](/zh/reference/middlewares)中了解更多。
 
 ```typescript
-import { ValidationMiddleware, AuthMiddleware } from './middleware';
-
 @Controller('/api/users')
 export class UserController {
   @Get('/', ValidationMiddleware)
-  getAllUsers() {
-    // 只有这个路由有ValidationMiddleware
-  }
-
-  @Post('/', AuthMiddleware, ValidationMiddleware)
-  createUser() {
-    // 这个路由有两个中间件
-  }
+  getAllUsers() {}
 }
 ```
 
 ## 参数装饰器
 
-使用参数装饰器从HTTP请求中提取数据。所有参数装饰器都可以带参数名或不带参数名使用，以提取特定值或整个对象。
-
-### 请求对象访问
-
-- `@Req()` - 访问Express Request对象（无参数）
-- `@Res()` - 访问Express Response对象（无参数）
-- `@Next()` - 访问Express NextFunction（无参数）
-
-访问Express请求、响应和next对象：
-
-```typescript
-import { Request, Response, NextFunction } from 'express';
-
-@Controller('/api/users')
-export class UserController {
-  @Get('/')
-  getAllUsers(
-    @Req() request: Request,
-    @Res() response: Response,
-    @Next() next: NextFunction
-  ) {
-    // 直接访问Express对象
-    console.log(request.url);
-    return { users: [] };
-  }
-}
-```
-
-### 提取路由参数
-
-- `@Param(name?)` - 提取路由参数（可选参数名）
-
-```typescript
-@Controller('/api/users')
-export class UserController {
-  @Get('/:id')
-  getUser(@Param('id') id: string) {
-    // 提取特定参数
-    return { userId: id };
-  }
-
-  @Get('/:id/posts/:postId')
-  getUserPost(
-    @Param('id') userId: string,
-    @Param('postId') postId: string
-  ) {
-    // 提取多个参数
-    return { userId, postId };
-  }
-
-  @Get('/all')
-  getAllWithParams(@Param() params: any) {
-    // 获取所有路由参数作为对象
-    return { params };
-  }
-}
-```
-
-### 提取查询参数
-
-- `@Query(name?)` - 提取查询参数（可选参数名）
-
-```typescript
-@Controller('/api/users')
-export class UserController {
-  @Get('/')
-  getUsers(
-    @Query('page') page: number = 1,
-    @Query('limit') limit: number = 10
-  ) {
-    // 提取特定查询参数并设置默认值
-    return { page, limit };
-  }
-
-  @Get('/search')
-  searchUsers(@Query() query: any) {
-    // 获取所有查询参数作为对象
-    return { searchParams: query };
-  }
-}
-```
+使用参数装饰器从HTTP请求中提取数据。YasuiJS根据TypeScript类型自动转换参数以获得更好的类型安全性。
 
 ### 提取请求体
 
-- `@Body(name?)` - 提取请求体数据（可选参数名）
+- `@Body(name?)` - 提取请求体数据
 
 ```typescript
 @Controller('/api/users')
@@ -243,23 +125,76 @@ export class UserController {
 }
 ```
 
-### 提取请求头
+### 提取参数和请求头
 
-- `@Header(name?)` - 提取请求头（可选参数名）
+- `@Param(name)` - 提取路由参数
+- `@Query(name)` - 提取查询参数
+- `@Header(name?)` - 提取请求头
+
+参数会根据TypeScript类型自动转换：
 
 ```typescript
 @Controller('/api/users')
 export class UserController {
-  @Get('/')
-  getUsers(@Header('authorization') auth: string) {
-    // 提取特定请求头
-    return { authHeader: auth };
+  @Get('/:id')
+  getUser(@Param('id') id: number) { 
+    // 自动转换为数字
   }
 
-  @Get('/all-headers')
-  getUsersWithHeaders(@Header() headers: any) {
-    // 获取所有请求头作为对象
-    return { headers };
+  @Get('/search')
+  searchUsers(
+    @Query('page') page: number,
+    @Query('active') active: boolean,
+    @Query('tags') tags: string[]
+  ) {
+    // page: number (从"123"转换为123)
+    // active: boolean (从"true"/"1"转换为true)
+    // tags: string[] (来自?tags=red&tags=blue)
+    return { page, active, tags };
+  }
+
+  @Get('/profile')
+  getProfile(
+    @Query('settings') settings: { theme: string },
+    @Header('x-api-version') version: number
+  ) {
+    // settings: object (从?settings={"theme":"dark"} - JSON解析)
+    // version: number (请求头转换为数字)
+    return { settings, version };
+  }
+}
+```
+
+### 支持的类型转换
+
+YasuiJS根据TypeScript类型自动转换参数：
+
+- **string** - 无转换（默认）
+- **number** - 转换为数字，无效时返回NaN
+- **boolean** - 将"true"/"1"转换为true，其他转换为false
+- **Date** - 转换为Date对象，无效时返回Invalid Date
+- **string[]** - 用于查询数组如`?tags=red&tags=blue`
+- **object** - 解析JSON字符串，用于查询如`?data={"key":"value"}`
+
+### 请求对象访问
+
+- `@Req()` - 访问Express Request对象
+- `@Res()` - 访问Express Response对象
+- `@Next()` - 访问Express NextFunction
+
+```typescript
+import { Request, Response, NextFunction } from 'yasui';
+
+@Controller('/api/users')
+export class UserController {
+  @Get('/')
+  getAllUsers(
+    @Req() request: Request,
+    @Res() response: Response,
+    @Next() next: NextFunction
+  ) {
+    console.log(request.url);
+    return { users: [] };
   }
 }
 ```
@@ -270,14 +205,14 @@ YasuiJS自动处理响应序列化和状态码。
 
 ### 自动JSON响应
 
-返回任何数据，它将自动序列化为JSON：
+返回任何数据都将自动序列化为JSON：
 
 ```typescript
 @Controller('/api/users')
 export class UserController {
   @Get('/')
   getUsers() {
-    // 自动返回JSON，状态码为200
+    // 自动返回JSON，状态码200
     return { users: ['John', 'Jane'] };
   }
 
@@ -297,7 +232,7 @@ export class UserController {
 
 ### 自定义状态码
 
-- `@HttpStatus(code)` - 设置自定义HTTP状态码（必需状态码参数，接受数字或HttpCode枚举）
+- `@HttpStatus(code)` - 设置自定义HTTP状态码
 
 使用`@HttpStatus()`装饰器设置自定义状态码：
 
@@ -306,15 +241,8 @@ import { HttpStatus, HttpCode } from 'yasui';
 
 @Controller('/api/users')
 export class UserController {
-  @Post('/')
-  @HttpStatus(201) // 使用数字
-  createUser(@Body() userData: any) {
-    // 返回状态码201 Created
-    return { created: userData };
-  }
-
   @Post('/alt')
-  @HttpStatus(HttpCode.CREATED) // 使用HttpCode枚举
+  @HttpStatus(201) // 使用数字
   createUserAlt(@Body() userData: any) {
     // 返回状态码201 Created
     return { created: userData };
@@ -324,55 +252,31 @@ export class UserController {
   @HttpStatus(HttpCode.NO_CONTENT) // 使用HttpCode枚举
   deleteUser(@Param('id') id: string) {
     // 返回状态码204 No Content
-    // 对于204可以不返回任何内容
+    // 204可以不返回任何内容
   }
 }
 ```
 
 ### 手动响应处理
 
-要完全控制，请使用Express响应对象：
+要完全控制，使用Express响应对象：
 
 ```typescript
-import { Response } from 'express';
+import { Response } from 'yasui';
 
 @Controller('/api/users')
 export class UserController {
   @Get('/custom')
   customResponse(@Res() res: Response) {
     res.status(418).json({ 
-      message: "I'm a teapot",
+      message: "我是茶壶",
       custom: true 
     });
     // 直接使用res时不要返回任何内容
-  }
-
-  @Get('/file')
-  downloadFile(@Res() res: Response) {
-    res.download('/path/to/file.pdf');
   }
 }
 ```
 
 ## 错误处理
 
-让框架自动处理错误或抛出自定义错误。有关完整的错误处理详情，请参阅[错误处理](/zh/reference/error-handling)。
-
-```typescript
-import { HttpError, HttpCode } from 'yasui';
-
-@Controller('/api/users')
-export class UserController {
-  @Get('/:id')
-  getUser(@Param('id') id: string) {
-    const user = this.userService.findById(id);
-    
-    if (!user) {
-      // 抛出自定义HTTP错误
-      throw new HttpError(HttpCode.NOT_FOUND, 'User not found');
-    }
-    
-    return user;
-  }
-}
-```
+让框架自动处理错误或抛出自定义错误。完整的错误处理详情，请参见[错误处理](/zh/reference/error-handling)。

--- a/docs/zh/reference/dependency-injection.md
+++ b/docs/zh/reference/dependency-injection.md
@@ -1,10 +1,10 @@
 # 依赖注入
 
-YasuiJS提供了一个完整的依赖注入系统，具有自动解析依赖关系和作用域管理功能。它实现了松耦合、更好的可测试性和更清晰的关注点分离。
+YasuiJS 提供了一个完整的依赖注入系统，具有自动解析依赖关系和作用域管理功能。它实现了松耦合、更好的可测试性和更清晰的关注点分离。
 
 ## 概述
 
-依赖注入自动管理组件之间的关系。无需手动创建和连接对象，YasuiJS通过分析类构造函数和方法参数为您完成这项工作。
+依赖注入自动管理组件之间的关系。YasuiJS 通过分析类构造函数和方法参数来自动创建和连接对象，而不是手动创建和连接对象。
 
 ```typescript
 import { Injectable, Controller } from 'yasui';
@@ -30,11 +30,11 @@ export class UserController {
 
 ## 可注入服务
 
-### Injectable装饰器
+### Injectable 装饰器
 
 - `@Injectable()` - 将类标记为可注入（无参数，所有服务都需要）
 
-使用`@Injectable()`装饰器将类标记为可注入。这个装饰器对所有将被注入的服务来说是**必需的**。
+使用 `@Injectable()` 装饰器将类标记为可注入。此装饰器对所有将被注入的服务来说都是**必需的**。
 
 ```typescript
 import { Injectable } from 'yasui';
@@ -42,7 +42,7 @@ import { Injectable } from 'yasui';
 @Injectable()
 export class UserService {
   getUser(id: string) {
-    // 业务逻辑在这里
+    // 业务逻辑
     return { id, name: 'John Doe' };
   }
 }
@@ -50,7 +50,7 @@ export class UserService {
 @Injectable()
 export class EmailService {
   sendEmail(to: string, subject: string) {
-    // 邮件逻辑在这里
+    // 邮件逻辑
     console.log(`Sending email to ${to}: ${subject}`);
   }
 }
@@ -58,7 +58,7 @@ export class EmailService {
 
 ## 构造函数注入
 
-只需在控制器、中间件或服务构造函数中声明您的依赖项。您可以在同一个构造函数中注入多个服务。它们将被自动解析和注入：
+只需在控制器、中间件或服务构造函数中声明依赖项。您可以在同一个构造函数中注入多个服务。它们将被自动解析和注入：
 
 ```typescript
 @Injectable()
@@ -81,21 +81,21 @@ export class OrderService {
 
 ## 依赖作用域
 
-### Scope装饰器
+### Scope 装饰器
 
 - `@Scope(scope)` - 指定依赖作用域（需要作用域参数）
 
-YasuiJS支持三种不同的依赖作用域，控制实例如何创建和共享：
+YasuiJS 支持三种不同的依赖作用域，用于控制实例的创建和共享方式：
 
-- **`Scopes.SHARED`**（默认）：整个应用程序共享的单例实例
-- **`Scopes.LOCAL`**：每个注入上下文创建新实例
+- **`Scopes.SHARED`**（默认）：在整个应用程序中共享的单例实例
+- **`Scopes.LOCAL`**：为每个注入上下文创建新实例
 - **`Scopes.DEEP_LOCAL`**：创建新实例，并将局部性传播到其自身的依赖项
 
-`@Scope()`装饰器应用于注入点，而不是服务类本身。
+`@Scope()` 装饰器应用于注入点，而不是服务类本身。
 
-### 构造函数级别的作用域
+### 构造函数级作用域
 
-您可以在构造函数中为各个依赖项指定作用域：
+您可以在构造函数中为单个依赖项指定作用域：
 
 ```typescript
 @Injectable()
@@ -103,7 +103,7 @@ export class MyService {
   constructor(
     @Scope(Scopes.LOCAL) private tempService: TempService,
     @Scope(Scopes.DEEP_LOCAL) private isolatedService: IsolatedService,
-    private sharedService: SharedService // 默认为SHARED
+    private sharedService: SharedService // 默认为 SHARED
   ) {}
 }
 ```
@@ -111,33 +111,30 @@ export class MyService {
 ### 作用域选择指南
 
 - **SHARED**：用于无状态服务、缓存、数据库连接
-- **LOCAL**：用于特定请求的服务、临时处理器
+- **LOCAL**：用于请求特定的服务、临时处理器
 - **DEEP_LOCAL**：用于完全隔离的操作、测试场景
 
 ## 方法级注入
 
-### Inject装饰器
+### Inject 装饰器
 
-- `@Inject(token?)` - 将依赖项注入到方法参数中（可选自定义令牌）
+- `@Inject(token?)` - 将依赖项注入到方法参数中（可选的自定义令牌）
 
-您可以直接将依赖项注入到控制器或中间件方法参数中。这将注入限制在特定端点而不是整个控制器，允许精细的作用域管理。例如，您可以在构造函数中注入共享服务，但特定路由需要该服务的专用实例。
+您可以直接将依赖项注入到控制器或中间件方法参数中。这将注入限制在特定端点而不是整个控制器，允许细粒度的作用域管理。例如，您可以在构造函数中注入共享服务，但特定路由需要同一服务的专用实例。
 
 ```typescript
 @Controller('/users')
 export class UserController {
-  constructor(private userService: UserService) {} // 控制器的共享实例
+
+  // 控制器的共享实例
+  constructor(private userService: UserService) {}
 
   @Get('/:id')
   getUser(
     @Param('id') id: string,
-    @Inject() userService: UserService // 特定于此端点的实例
+    @Inject() userService: UserService // 此端点的特定实例
   ) {
     return userService.getUser(id);
-  }
-
-  @Get('/')
-  getUsers(@Inject() userService: UserService) {
-    return userService.getAllUsers();
   }
 }
 ```
@@ -163,7 +160,7 @@ export class ApiController {
 
 ### 使用自定义令牌
 
-对于复杂场景，使用带有`@Inject()`的自定义注入令牌。这对于注入原始值、配置或当您需要同一类的多个实例时很有用：
+对于复杂场景，使用带有 `@Inject()` 的自定义注入令牌。这对于注入原始值、配置或当您需要同一个类的多个实例时很有用：
 
 ```typescript
 @Injectable()
@@ -219,7 +216,7 @@ yasui.createServer({
 
 ### 循环依赖
 
-YasuiJS在启动时自动检测并防止循环依赖：
+YasuiJS 在启动时自动检测并防止循环依赖：
 
 ```typescript
 // 这将被检测并报告为错误

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "preversion": "npm run lint",
     "precommit": "npm run lint",
     "commit": "npm run lint && format-commit",
+    "branch": "format-commit --branch",
     "docs:dev": "vitepress dev docs",
     "docs:build": "vitepress build docs",
     "docs:preview": "vitepress preview docs",
@@ -58,19 +59,19 @@
   },
   "devDependencies": {
     "@anthropic-ai/sdk": "^0.57.0",
-    "@eslint/js": "^9.31.0",
+    "@eslint/js": "^9.32.0",
     "@types/express": "^5.0.3",
-    "@types/node": "^24.0.15",
+    "@types/node": "^24.1.0",
     "@typescript-eslint/eslint-plugin": "^8.38.0",
     "@typescript-eslint/parser": "^8.38.0",
-    "eslint": "^9.31.0",
+    "eslint": "^9.32.0",
     "format-commit": "^0.4.0",
     "globals": "^16.3.0",
     "nodemon": "^3.1.10",
     "swagger-ui-express": "^5.0.1",
     "tsc-alias": "^1.8.16",
-    "typescript": "^5.8.3",
+    "typescript": "^5.9.2",
     "vitepress": "^1.6.3",
-    "vue": "^3.5.17"
+    "vue": "^3.5.18"
   }
 }

--- a/src/base.ts
+++ b/src/base.ts
@@ -25,6 +25,7 @@ export function createServer(conf: YasuiConfig): Server {
       core.logger.warn('server started with errors');
       core.logger.log(`server listens on port ${port}`);
       core.decoratorValidator.outputErrors();
+      core.decoratorValidator = null;
     } else {
       core.logger.success('server successfully started');
       core.logger.log(`server listens on port ${port}`);
@@ -37,5 +38,6 @@ export function createApp(conf: YasuiConfig): Application {
   const core: Core = new Core(conf);
   const app: Application = core.createApp();
   core.decoratorValidator?.outputErrors();
+  core.decoratorValidator = null;
   return app;
 }

--- a/src/core.ts
+++ b/src/core.ts
@@ -150,7 +150,11 @@ export class Core {
       const swaggerConfig = this.swagger.getSwaggerConfig(this.config.swagger?.info, !!this.config.apiKey);
 
       this.app.use(swaggerPath, swaggerUi.serve);
-      this.app.get(swaggerPath, swaggerUi.setup(swaggerConfig));
+      this.app.get(swaggerPath, swaggerUi.setup(swaggerConfig, {
+        swaggerOptions: {
+          defaultModelsExpandDepth: 0,
+        }
+      }));
       this.app.get(`${swaggerPath}/swagger.json`, (req, res) => {
         res.json(swaggerConfig);
       });

--- a/src/core.ts
+++ b/src/core.ts
@@ -40,7 +40,6 @@ export class Core {
     }
     this.logger = new LoggerService();
     this.appService = new AppService(this.config);
-    this.swagger = new SwaggerService();
     this.decoratorValidator = this.config.enableDecoratorValidation
       ? new DecoratorValidator(this.config)
       : null;
@@ -48,6 +47,9 @@ export class Core {
       this.logger,
       this.decoratorValidator,
       conf.debug,
+    );
+    this.swagger = new SwaggerService(
+      this.decoratorValidator,
     );
     this.app = express();
   }

--- a/src/decorators/injectable.decorator.ts
+++ b/src/decorators/injectable.decorator.ts
@@ -24,7 +24,7 @@ export function Inject(token?: string): ParameterDecorator {
       if (token) {
         methodsDeps[methodName][index] = token;
       } else {
-        const paramTypes = getMetadata(ReflectMetadata.DESIGN_TYPE, target, methodName) || [];
+        const paramTypes = getMetadata(ReflectMetadata.DESIGN_PARAM_TYPES, target, methodName) || [];
         methodsDeps[methodName][index] = <Constructible>paramTypes[index];
       }
       defineMetadata(ReflectMetadata.METHOD_INJECTED_DEPS, methodsDeps, target);

--- a/src/decorators/middleware.decorator.ts
+++ b/src/decorators/middleware.decorator.ts
@@ -25,6 +25,7 @@ export const Middleware = (): ClassDecorator => {
         target.prototype,
         descriptor,
         params,
+        true
       );
     };
   };

--- a/src/decorators/params.decorator.ts
+++ b/src/decorators/params.decorator.ts
@@ -35,6 +35,7 @@ function extractParam(
     if (!propertyKey) {
       return;
     }
+
     /** construct param access path */
     const path: string[] = [source];
     for (const node of [reqProperty, varName]) {
@@ -43,11 +44,17 @@ function extractParam(
       }
     }
 
+    const paramTypes = getMetadata(ReflectMetadata.DESIGN_PARAM_TYPES, target, propertyKey) || [];
+    const paramType = paramTypes[parameterIndex];
     const methodName = String(propertyKey);
-    const routeParam: IRouteParam = { index: parameterIndex, path };
-    const routeParams = getMetadata(ReflectMetadata.PARAMS, target, methodName) || [];
-
+    const routeParam: IRouteParam = { 
+      index: parameterIndex, 
+      type: paramType,
+      path,
+    };
+  
     /** add mapped param to route metadata */
+    const routeParams = getMetadata(ReflectMetadata.PARAMS, target, methodName) || [];
     defineMetadata(
       ReflectMetadata.PARAMS,
       [...routeParams, routeParam],

--- a/src/examples/tests.controller.ts
+++ b/src/examples/tests.controller.ts
@@ -1,10 +1,10 @@
 import {
+  ApiErrorResponse,
   ApiOperation,
   ApiParam,
   ApiResponse,
   Body,
   Controller,
-  ErrorResourceSchema,
   Get,
   Header,
   HttpStatus,
@@ -51,12 +51,12 @@ export class TestsController {
 
   @Put('/')
   @ApiOperation('Simulate error 500', 'Deliberately throws an error for testing purposes')
-  @ApiResponse(500, 'Internal server error', ErrorResourceSchema())
+  @ApiErrorResponse(500, 'Internal server error simulation')
   private error(): void {
     /**
-       * custom error must inherit from Error and have a status property
-       * 500 (Internal server error) is returned by default
-       */
+     * custom error must inherit from Error and have a status property
+     * 500 (Internal server error) is returned by default
+     */
     throw new Error('I just simulate an error.');
   }
 }

--- a/src/injector.ts
+++ b/src/injector.ts
@@ -75,7 +75,7 @@ export class Injector {
     scope: Scopes
   ): Instance[] {
     /** inject via constructor param types or pre-registered token injections */
-    const deps = getMetadata(ReflectMetadata.DESIGN_TYPE, Provided) || [];
+    const deps = getMetadata(ReflectMetadata.DESIGN_PARAM_TYPES, Provided) || [];
     const preInjectedDeps = getMetadata(ReflectMetadata.PRE_INJECTED_DEPS, Provided) || {};
 
     const depScopes = getMetadata(ReflectMetadata.DEP_SCOPES, Provided) || {};

--- a/src/utils/app.service.ts
+++ b/src/utils/app.service.ts
@@ -43,9 +43,8 @@ export class AppService {
     req: Request,
     res: Response,
   ): void {
-    const message = `Cannot resolve ${req.method} ${req.path}`;
+    this.logger.error(`Cannot resolve ${req.method} ${req.path}`);
     res.sendStatus(HttpCode.NOT_FOUND);
-    this.logger.error(message);
   }
 
   /** pretty logs and client responses for errors */

--- a/src/utils/decorator-validator.ts
+++ b/src/utils/decorator-validator.ts
@@ -8,6 +8,7 @@ import {
 import { ReflectMetadata, Scopes } from '~types/enums';
 import { LoggerService } from '../services';
 import { getMetadata } from './reflect';
+import { SwaggerService } from './swagger.service';
 
 
 interface ValidationError {
@@ -97,7 +98,7 @@ export class DecoratorValidator {
       }
     }
 
-    const deps = getMetadata(ReflectMetadata.DESIGN_TYPE, target) || [];
+    const deps = getMetadata(ReflectMetadata.DESIGN_PARAM_TYPES, target) || [];
     const preInjectedDeps = getMetadata(ReflectMetadata.PRE_INJECTED_DEPS, target) || {};
 
     deps.forEach((Dep, idx) => {
@@ -137,6 +138,20 @@ export class DecoratorValidator {
     }
   }
 
+  public validateSwaggerSchemaName(
+    callerName: string,
+    name: string
+  ): void {
+    const existingSchemaClass = SwaggerService.schemas.get(name)?.className;
+    if (existingSchemaClass !== callerName) {
+      this.addError(
+        callerName,
+        `Schema '${name}' already exists (Class ${existingSchemaClass})`,
+        'Use a different name for your schema'
+      );
+    }
+  }
+
 
   private validateRouteMethod(
     className: string,
@@ -146,7 +161,7 @@ export class DecoratorValidator {
     if (!prototype[route.methodName]) {
       return;
     }
-    const paramTypes = getMetadata(ReflectMetadata.DESIGN_TYPE, prototype, route.methodName) || [];
+    const paramTypes = getMetadata(ReflectMetadata.DESIGN_PARAM_TYPES, prototype, route.methodName) || [];
     const paramNames = this.getParameterNames(prototype[route.methodName]);
 
     const methodsInjections = getMetadata(ReflectMetadata.METHOD_INJECTED_DEPS, prototype) || {};

--- a/src/utils/error.resource.ts
+++ b/src/utils/error.resource.ts
@@ -2,7 +2,7 @@ import { italic } from 'kleur';
 import { Request } from 'express';
 
 import { HttpCode, HttpCodeMap } from '~types/enums';
-import { OpenAPISchema } from '~types/openapi';
+import { ObjectSchema, OpenAPISchema } from '~types/openapi';
 
 
 export class HttpError extends Error {
@@ -66,14 +66,14 @@ export class ErrorResource {
 export function ErrorResourceSchema<T extends Record<string, any> = Record<string, any>>(
   additionalProperties: Record<string, OpenAPISchema> = {},
   additionalPropertiesExample?: T,
-): OpenAPISchema {
+): ObjectSchema {
   return {
     type: 'object',
     properties: {
       url: {
         type: 'string',
         format: 'uri',
-        description: 'Full URL of the request that caused the error',
+        description: 'Request URL',
         example: 'http://localhost:3000/api/tests'
       },
       path: {
@@ -84,7 +84,7 @@ export function ErrorResourceSchema<T extends Record<string, any> = Record<strin
       method: {
         type: 'string',
         enum: ['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'OPTIONS', 'HEAD'],
-        description: 'HTTP method used',
+        description: 'HTTP method',
         example: 'PUT'
       },
       name: {

--- a/src/utils/error.resource.ts
+++ b/src/utils/error.resource.ts
@@ -2,7 +2,7 @@ import { italic } from 'kleur';
 import { Request } from 'express';
 
 import { HttpCode, HttpCodeMap } from '~types/enums';
-import { ObjectSchema, OpenAPISchema } from '~types/openapi';
+import { ObjectSchema } from '~types/openapi';
 
 
 export class HttpError extends Error {
@@ -60,13 +60,7 @@ export class ErrorResource {
   }
 }
 
-
-/** error schema for Swagger/OpenAPI response decorators */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function ErrorResourceSchema<T extends Record<string, any> = Record<string, any>>(
-  additionalProperties: Record<string, OpenAPISchema> = {},
-  additionalPropertiesExample?: T,
-): ObjectSchema {
+export function ErrorResourceSchema(statusCode: number = 500): ObjectSchema {
   return {
     type: 'object',
     properties: {
@@ -100,31 +94,20 @@ export function ErrorResourceSchema<T extends Record<string, any> = Record<strin
       statusMessage: {
         type: 'string',
         description: 'HTTP status message',
-        example: 'Internal Server Error'
+        example: HttpCodeMap[statusCode]
       },
       status: {
         type: 'integer',
         minimum: 100,
         maximum: 599,
         description: 'HTTP status code',
-        example: 500
+        example: statusCode
       },
       data: {
         type: 'object',
-        properties: additionalProperties,
         description: 'Additional error data and extended properties',
         example: {}
       }
-    },
-    example: {
-      url: 'http://localhost:3000/api/tests',
-      path: '/api/tests',
-      method: 'PUT',
-      name: 'Error',
-      message: 'I just simulate an error.',
-      statusMessage: 'Internal Server Error',
-      status: 500,
-      data: additionalPropertiesExample || {},
     }
   };
 };

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,8 +1,6 @@
 import { SwaggerService } from './swagger.service';
 
-/**
- * Export only utils provided outside sources
- */
+/** Export only utils provided outside sources */
 
-export { HttpError, ErrorResourceSchema } from './error.resource';
+export { HttpError } from './error.resource';
 export const resolveSchema = SwaggerService.resolveSchema;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,5 +1,8 @@
+import { SwaggerService } from './swagger.service';
+
 /**
  * Export only utils provided outside sources
  */
 
 export { HttpError, ErrorResourceSchema } from './error.resource';
+export const resolveSchema = SwaggerService.resolveSchema;

--- a/src/utils/swagger.ts
+++ b/src/utils/swagger.ts
@@ -1,5 +1,30 @@
+import { ApiPropertyDefinition } from '~types/interfaces';
 import { OpenAPISchema } from '~types/openapi';
 
+
+export type DecoratorUsage =
+  | 'PrimitiveSchema'
+  | 'RefSchema'
+  | 'ObjectSchema'
+  | 'Array'
+  | 'Enum'
+  | 'Constructible'
+  | 'Record';
+
+export function extractDecoratorUsage(def: ApiPropertyDefinition): DecoratorUsage {
+  if (typeof def === 'function') {
+    return 'Constructible';
+  } else if (Array.isArray(def)) {
+    return 'Array';
+  } else if ('$ref' in def) {
+    return 'RefSchema';
+  } else if ('type' in def) {
+    return def.type === 'object' ? 'ObjectSchema' : 'PrimitiveSchema';
+  } else if ('enum' in def) {
+    return 'Enum';
+  }
+  return 'Record';
+}
 
 export function mapTypeToSchema(type: Function): OpenAPISchema {
   switch (type) {

--- a/src/utils/swagger.ts
+++ b/src/utils/swagger.ts
@@ -1,0 +1,18 @@
+import { OpenAPISchema } from '~types/openapi';
+
+
+export function mapTypeToSchema(type: Function): OpenAPISchema {
+  switch (type) {
+    case String: return { type: 'string' };
+    case Number: return { type: 'number' };
+    case Boolean: return { type: 'boolean' };
+    case Date: return { type: 'string', format: 'date-time' };
+    case Array: return { type: 'array', items: { type: 'string' } };
+    case Object: return { type: 'object' };
+    default:
+      if (type.name && type.name !== 'Object') {
+        return { $ref: '' };
+      }
+      return { type: 'object' };
+  }
+}


### PR DESCRIPTION
feat: enhance Swagger decorators with flexible schema definitions, and automatic parameter type conversion

- Add support for enums, arrays, class references, and record objects in @ApiProperty
- Introduce @ApiErrorResponse for comprehensive error documentation 
- Add @ApiSchema decorator for custom schema naming
- Implement automatic type conversion for @Param, @Query, @Header (string/number/boolean/Date/Array/Object)
- Support object parsing from query parameters (?param[key]=value)
- Add resolveSchema utility function for manual schema resolution
- Fix middleware response handling to prevent header conflicts